### PR TITLE
fix for issue 61

### DIFF
--- a/innvestigate/analyzer/base.py
+++ b/innvestigate/analyzer/base.py
@@ -327,7 +327,7 @@ class AnalyzerNetworkBase(AnalyzerBase):
         if neuron_selection_mode == "max_activation":
             model_output = ilayers.Max()(model_output)
         elif neuron_selection_mode == "index":
-            neuron_indexing = keras.layers.Input(shape=[None], dtype=np.int32)
+            neuron_indexing = keras.layers.Input(shape=[None], dtype=np.int32, name='innvestigate_input_selindex')
             neuron_selection_inputs += [neuron_indexing]
 
             model_output = ilayers.Gather()(model_output+[neuron_indexing])


### PR DESCRIPTION
Hi Max,

basic change is:

neuron_indexing = keras.layers.Input(shape=[None], dtype=np.int32, name='innvestigate_input_selindex')

then that layer gets a different name from input_1 - which can collide with models from the model zoo which like the Densenets have already input tensors with name input_1