### PR TITLE
setup.py: Fix character encoding when reading README.md for utf8 characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 def readme():
     base_dir = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(base_dir, 'README.md')) as f:
+    with open(os.path.join(base_dir, 'README.md'), 'r', encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Installation failed because of author names which include utf-8 characters which cannot be represented in ASCII.