### PR TITLE
Random and Smoothgrad analyzer quick fixes

### DIFF
--- a/innvestigate/analyzer/misc.py
+++ b/innvestigate/analyzer/misc.py
@@ -45,12 +45,12 @@ class Random(AnalyzerNetworkBase):
     """
 
     def __init__(self, model, stddev=1, **kwargs):
-        self._stddev = 1
+        self._stddev = stddev
 
         super(Random, self).__init__(model, **kwargs)
 
     def _create_analysis(self, model, stop_analysis_at_tensors=[]):
-        noise = ilayers.TestPhaseGaussianNoise(stddev=1)
+        noise = ilayers.TestPhaseGaussianNoise(stddev=self._stddev)
         tensors_to_analyze = [x for x in iutils.to_list(model.inputs)
                               if x not in stop_analysis_at_tensors]
         return [noise(x) for x in tensors_to_analyze]

--- a/innvestigate/analyzer/wrapper.py
+++ b/innvestigate/analyzer/wrapper.py
@@ -129,7 +129,7 @@ class AugmentReduceBase(WrapperBase):
                             "with this wrapper.")
 
         new_inputs = iutils.to_list(self._augment(inputs))
-        print(type(new_inputs), type(extra_inputs))
+        # print(type(new_inputs), type(extra_inputs))
         tmp = iutils.to_list(model(new_inputs+extra_inputs))
         new_outputs = iutils.to_list(self._reduce(tmp))
         new_constant_inputs = self._keras_get_constant_inputs()
@@ -151,6 +151,7 @@ class AugmentReduceBase(WrapperBase):
                     indices = np.argmax(tmp, axis=1)
                 else:
                     if len(args):
+                        args = list(args)
                         indices = args.pop(0)
                     else:
                         indices = kwargs.pop("neuron_selection")


### PR DESCRIPTION
Quick fixes for issues #132 and #133.

- use standard deviation keyword in **Random** analyzer
- cast `*args` to list at problematic line in [wrapper.py](https://github.com/albermax/innvestigate/blob/master/innvestigate/analyzer/wrapper.py), which for some reason was a tuple when using **Smoothgrad** analyzer in neuron selection mode `"index"`. (A cleaner solution would probably be to trace back where the tuple actually comes from...)

