### PR TITLE
Some DeepLIFT bugfixes

### DIFF
--- a/innvestigate/analyzer/deeplift.py
+++ b/innvestigate/analyzer/deeplift.py
@@ -332,7 +332,7 @@ class DeepLIFTWrapper(base.AnalyzerNetworkBase):
                           progress_update=None)
 
     def analyze(self, X, neuron_selection=None):
-        if not hasattr(self, "_deep_lift_func"):
+        if not hasattr(self, "_func"):
             self._create_deep_lift_func()
 
         X = iutils.to_list(X)

--- a/innvestigate/analyzer/deeplift.py
+++ b/innvestigate/analyzer/deeplift.py
@@ -278,6 +278,8 @@ class DeepLIFTWrapper(base.AnalyzerNetworkBase):
         self._nonlinear_mode = kwargs.pop("nonlinear_mode", "rescale")
         self._reference_inputs = kwargs.pop("reference_inputs", 0)
         self._verbose = kwargs.pop("verbose", False)
+        #relevant for "index" selection mode
+        self._batch_size = kwargs.pop("batch_size", 32)
         self._add_model_softmax_check()
 
         try:
@@ -327,7 +329,7 @@ class DeepLIFTWrapper(base.AnalyzerNetworkBase):
                           input_data_list=X,
                           batch_size=batch_size,
                           input_references_list=self._references,
-                          progress_update=1000000)
+                          progress_update=None)
 
     def analyze(self, X, neuron_selection=None):
         if not hasattr(self, "_deep_lift_func"):
@@ -351,7 +353,7 @@ class DeepLIFTWrapper(base.AnalyzerNetworkBase):
                 raise ValueError("One neuron can be selected with DeepLIFT.")
 
             neuron_idx = neuron_selection[0]
-            analysis = self._analyze_with_deeplift(X, neuron_idx, len(X[0]))
+            analysis = self._analyze_with_deeplift(X, neuron_idx, self.batch_size)
 
             # Parse the output.
             ret = []

--- a/innvestigate/analyzer/deeplift.py
+++ b/innvestigate/analyzer/deeplift.py
@@ -353,7 +353,7 @@ class DeepLIFTWrapper(base.AnalyzerNetworkBase):
                 raise ValueError("One neuron can be selected with DeepLIFT.")
 
             neuron_idx = neuron_selection[0]
-            analysis = self._analyze_with_deeplift(X, neuron_idx, self.batch_size)
+            analysis = self._analyze_with_deeplift(X, neuron_idx, self._batch_size)
 
             # Parse the output.
             ret = []


### PR DESCRIPTION
Hello,

@jeremy-wendt alerted me to some slowdowns he was experiencing when running DeepLIFT through the iNNvestigate package. I did some innvestigation (please forgive the terrible pun) and I think I've tracked down the source of the issue; the DeepLIFT function was being recompiled every time analyze() was called. This is because analyze() was checking whether the analyzer had the attribute `_deep_lift_func` before doing the compilation, when in fact the compiled deeplift function was being stored under the attribute `_func`. Replacing `_deep_lift_func` with `_func` fixes this.

While I was there I also made a couple of other small fixes - first, I noticed that when the neuron selection mode was "index", the batch size was set to be the same as the length of the user-provided `X`. However, this can sometimes be very large and can cause out-of-memory errors; I added an argument to the constructor to allow the user to specify a batch size (defaults to 32).

Second, I noticed that progress_update was set to the very large 1000000 presumably because you didn't want DeepLIFT printing out progress updates; the way to achieve that is just to set progress_update to "None"; that way, you won't get the annoying "Done 0" message printed at the beginning.

I've verified the functionality in this github gist: https://colab.research.google.com/gist/AvantiShri/9795532a1f212887c7a5c2de92e1fd4a/jeremy_innvestigate_deeplift.ipynb

Let me know if there are any issues and thanks for including DeepLIFT in this package! 

-Av (creator of DeepLIFT)