### PR TITLE
[WIP:] refactoring for tensorflow2 keras compat

### DIFF
--- a/innvestigate/analyzer/base.py
+++ b/innvestigate/analyzer/base.py
@@ -9,9 +9,9 @@ import six
 ###############################################################################
 
 
-import keras.backend as K
-import keras.layers
-import keras.models
+import tensorflow.keras.backend as K
+import tensorflow.keras.layers
+import tensorflow.keras.models
 import numpy as np
 import warnings
 
@@ -49,7 +49,7 @@ class AnalyzerBase(object):
 
     This class defines the basic interface for analyzers:
 
-    >>> model = create_keras_model()
+    >>> model = create_tensorflow.keras_model()
     >>> a = Analyzer(model)
     >>> a.fit(X_train)  # If analyzer needs training.
     >>> analysis = a.analyze(X_test)
@@ -190,7 +190,7 @@ class AnalyzerBase(object):
         disable_model_checks = state.pop("disable_model_checks")
         assert len(state) == 0
 
-        model = keras.models.model_from_json(model_json)
+        model = tensorflow.keras.models.model_from_json(model_json)
         model.set_weights(model_weights)
         return {"model": model,
                 "disable_model_checks": disable_model_checks}
@@ -330,7 +330,7 @@ class AnalyzerNetworkBase(AnalyzerBase):
         self._allow_lambda_layers = allow_lambda_layers
         self._add_model_check(
             lambda layer: (not self._allow_lambda_layers and
-                           isinstance(layer, keras.layers.core.Lambda)),
+                           isinstance(layer, tensorflow.keras.layers.Lambda)),
             ("Lamda layers are not allowed. "
              "To force use set allow_lambda_layers parameter."),
             check_type="exception",
@@ -368,18 +368,18 @@ class AnalyzerNetworkBase(AnalyzerBase):
 
         # Flatten to form (batch_size, other_dimensions):
         if K.ndim(model_output[0]) > 2:
-            model_output = keras.layers.Flatten()(model_output)
+            model_output = tensorflow.keras.layers.Flatten()(model_output[0])
 
         if neuron_selection_mode == "max_activation":
             l = ilayers.Max(name="iNNvestigate_max")
             model_output = l(model_output)
             self._special_helper_layers.append(l)
         elif neuron_selection_mode == "index":
-            neuron_indexing = keras.layers.Input(
+            neuron_indexing = tensorflow.keras.layers.Input(
                 batch_shape=[None, None], dtype=np.int32,
                 name='iNNvestigate_neuron_indexing')
             self._special_helper_layers.append(
-                neuron_indexing._keras_history[0])
+                neuron_indexing._tensorflow.keras_history[0])
             analysis_inputs.append(neuron_indexing)
             # The indexing tensor should not be analyzed.
             stop_analysis_at_tensors.append(neuron_indexing)
@@ -392,7 +392,7 @@ class AnalyzerNetworkBase(AnalyzerBase):
         else:
             raise NotImplementedError()
 
-        model = keras.models.Model(inputs=model_inputs+analysis_inputs,
+        model = tensorflow.keras.models.Model(inputs=model_inputs+analysis_inputs,
                                    outputs=model_output)
         return model, analysis_inputs, stop_analysis_at_tensors
 
@@ -432,7 +432,7 @@ class AnalyzerNetworkBase(AnalyzerBase):
         self._n_constant_input = len(constant_inputs)
         self._n_data_output = len(analysis_outputs)
         self._n_debug_output = len(debug_outputs)
-        self._analyzer_model = keras.models.Model(
+        self._analyzer_model = tensorflow.keras.models.Model(
             inputs=model_inputs+analysis_inputs+constant_inputs,
             outputs=analysis_outputs+debug_outputs)
 

--- a/innvestigate/analyzer/deeptaylor.py
+++ b/innvestigate/analyzer/deeptaylor.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.layers
-import keras.models
+import tensorflow.keras.layers
+import tensorflow.keras.models
 
 
 from . import base
@@ -91,20 +91,20 @@ class DeepTaylor(base.ReverseAnalyzerBase):
             name="deep_taylor_average_pooling",
         )
         self._add_conditional_reverse_mapping(
-            lambda l: isinstance(l, keras.layers.Add),
+            lambda l: isinstance(l, tensorflow.keras.layers.Add),
             # Ignore scaling with 0.5
             self._gradient_reverse_mapping,
             name="deep_taylor_add",
         )
         self._add_conditional_reverse_mapping(
             lambda l: isinstance(l, (
-                keras.layers.convolutional.UpSampling1D,
-                keras.layers.convolutional.UpSampling2D,
-                keras.layers.convolutional.UpSampling3D,
-                keras.layers.core.Dropout,
-                keras.layers.core.SpatialDropout1D,
-                keras.layers.core.SpatialDropout2D,
-                keras.layers.core.SpatialDropout3D,
+                tensorflow.keras.layers.convolutional.UpSampling1D,
+                tensorflow.keras.layers.convolutional.UpSampling2D,
+                tensorflow.keras.layers.convolutional.UpSampling3D,
+                tensorflow.keras.layers.core.Dropout,
+                tensorflow.keras.layers.core.SpatialDropout1D,
+                tensorflow.keras.layers.core.SpatialDropout2D,
+                tensorflow.keras.layers.core.SpatialDropout3D,
             )),
             self._gradient_reverse_mapping,
             name="deep_taylor_special_layers",
@@ -113,19 +113,19 @@ class DeepTaylor(base.ReverseAnalyzerBase):
         # Layers w/o transformation
         self._add_conditional_reverse_mapping(
             lambda l: isinstance(l, (
-                keras.engine.topology.InputLayer,
-                keras.layers.convolutional.Cropping1D,
-                keras.layers.convolutional.Cropping2D,
-                keras.layers.convolutional.Cropping3D,
-                keras.layers.convolutional.ZeroPadding1D,
-                keras.layers.convolutional.ZeroPadding2D,
-                keras.layers.convolutional.ZeroPadding3D,
-                keras.layers.Concatenate,
-                keras.layers.core.Flatten,
-                keras.layers.core.Masking,
-                keras.layers.core.Permute,
-                keras.layers.core.RepeatVector,
-                keras.layers.core.Reshape,
+                tensorflow.keras.engine.topology.InputLayer,
+                tensorflow.keras.layers.convolutional.Cropping1D,
+                tensorflow.keras.layers.convolutional.Cropping2D,
+                tensorflow.keras.layers.convolutional.Cropping3D,
+                tensorflow.keras.layers.convolutional.ZeroPadding1D,
+                tensorflow.keras.layers.convolutional.ZeroPadding2D,
+                tensorflow.keras.layers.convolutional.ZeroPadding3D,
+                tensorflow.keras.layers.Concatenate,
+                tensorflow.keras.layers.core.Flatten,
+                tensorflow.keras.layers.core.Masking,
+                tensorflow.keras.layers.core.Permute,
+                tensorflow.keras.layers.core.RepeatVector,
+                tensorflow.keras.layers.core.Reshape,
             )),
             self._gradient_reverse_mapping,
             name="deep_taylor_no_transform",
@@ -146,8 +146,8 @@ class DeepTaylor(base.ReverseAnalyzerBase):
         To be theoretically sound Deep-Taylor expects only positive outputs.
         """
 
-        positive_outputs = [keras.layers.ReLU()(x) for x in model.outputs]
-        model_with_positive_output = keras.models.Model(
+        positive_outputs = [tensorflow.keras.layers.ReLU()(x) for x in model.outputs]
+        model_with_positive_output = tensorflow.keras.models.Model(
             inputs=model.inputs, outputs=positive_outputs)
 
         return super(DeepTaylor, self)._prepare_model(

--- a/innvestigate/analyzer/gradient_based.py
+++ b/innvestigate/analyzer/gradient_based.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.models
-import keras
+import tensorflow.keras.models
+import tensorflow.keras
 
 
 from . import base
@@ -159,7 +159,7 @@ class InputTimesGradient(Gradient):
                               if x not in stop_analysis_at_tensors]
         gradients = super(InputTimesGradient, self)._create_analysis(
             model, stop_analysis_at_tensors=stop_analysis_at_tensors)
-        return [keras.layers.Multiply()([i, g])
+        return [tensorflow.keras.layers.Multiply()([i, g])
                 for i, g in zip(tensors_to_analyze, gradients)]
 
 
@@ -171,7 +171,7 @@ class InputTimesGradient(Gradient):
 class DeconvnetReverseReLULayer(kgraph.ReverseMappingBase):
 
     def __init__(self, layer, state):
-        self._activation = keras.layers.Activation("relu")
+        self._activation = tensorflow.keras.layers.Activation("relu")
         self._layer_wo_relu = kgraph.copy_layer_wo_activation(
             layer,
             name_template="reversed_%s",
@@ -217,7 +217,7 @@ class Deconvnet(base.ReverseAnalyzerBase):
 
 
 def GuidedBackpropReverseReLULayer(Xs, Ys, reversed_Ys, reverse_state):
-    activation = keras.layers.Activation("relu")
+    activation = tensorflow.keras.layers.Activation("relu")
     # Apply relus conditioned on backpropagated values.
     reversed_Ys = kutils.apply(activation, reversed_Ys)
 

--- a/innvestigate/analyzer/pattern_based.py
+++ b/innvestigate/analyzer/pattern_based.py
@@ -7,13 +7,10 @@ from __future__ import\
 ###############################################################################
 ###############################################################################
 
-import keras.activations
-import keras.engine.topology
-import keras.layers
-import keras.layers.core
-import keras.layers.pooling
-import keras.models
-import keras
+import tensorflow.keras.activations
+import tensorflow.keras.layers
+import tensorflow.keras.models
+import tensorflow.keras
 import numpy as np
 import warnings
 
@@ -39,21 +36,21 @@ __all__ = [
 
 
 SUPPORTED_LAYER_PATTERNNET = (
-    keras.engine.topology.InputLayer,
-    keras.layers.convolutional.Conv2D,
-    keras.layers.core.Dense,
-    keras.layers.core.Dropout,
-    keras.layers.core.Flatten,
-    keras.layers.core.Masking,
-    keras.layers.core.Permute,
-    keras.layers.core.Reshape,
-    keras.layers.Concatenate,
-    keras.layers.pooling.GlobalMaxPooling1D,
-    keras.layers.pooling.GlobalMaxPooling2D,
-    keras.layers.pooling.GlobalMaxPooling3D,
-    keras.layers.pooling.MaxPooling1D,
-    keras.layers.pooling.MaxPooling2D,
-    keras.layers.pooling.MaxPooling3D,
+    tensorflow.keras.layers.InputLayer,
+    tensorflow.keras.layers.Conv2D,
+    tensorflow.keras.layers.Dense,
+    tensorflow.keras.layers.Dropout,
+    tensorflow.keras.layers.Flatten,
+    tensorflow.keras.layers.Masking,
+    tensorflow.keras.layers.Permute,
+    tensorflow.keras.layers.Reshape,
+    tensorflow.keras.layers.Concatenate,
+    tensorflow.keras.layers.GlobalMaxPooling1D,
+    tensorflow.keras.layers.GlobalMaxPooling2D,
+    tensorflow.keras.layers.GlobalMaxPooling3D,
+    tensorflow.keras.layers.MaxPooling1D,
+    tensorflow.keras.layers.MaxPooling2D,
+    tensorflow.keras.layers.MaxPooling3D,
 )
 
 
@@ -75,7 +72,7 @@ class PatternNetReverseKernelLayer(kgraph.ReverseMappingBase):
         if "activation" in config:
             activation = config["activation"]
             config["activation"] = None
-        self._act_layer = keras.layers.Activation(
+        self._act_layer = tensorflow.keras.layers.Activation(
             activation,
             name="reversed_act_%s" % config["name"])
         self._filter_layer = kgraph.copy_layer_wo_activation(
@@ -106,7 +103,7 @@ class PatternNetReverseKernelLayer(kgraph.ReverseMappingBase):
 
         # First step: propagate through the activation layer.
         # Workaround for linear activations.
-        linear_activations = [None, keras.activations.get("linear")]
+        linear_activations = [None, tensorflow.keras.activations.get("linear")]
         if self._act_layer.activation in linear_activations:
             tmp = reversed_Ys
         else:

--- a/innvestigate/analyzer/relevance_based/relevance_analyzer.py
+++ b/innvestigate/analyzer/relevance_based/relevance_analyzer.py
@@ -9,23 +9,16 @@ import six
 ###############################################################################
 
 import inspect
-import keras
-import keras.backend as K
-import keras.engine.topology
-import keras.models
-import keras.layers
-import keras.layers.convolutional
-import keras.layers.core
-import keras.layers.local
-import keras.layers.noise
-import keras.layers.normalization
-import keras.layers.pooling
+import tensorflow.keras
+import tensorflow.keras.backend as K
+import tensorflow.keras.models
+import tensorflow.keras.layers
 
 
 from .. import base
 from innvestigate import layers as ilayers
 from innvestigate import utils as iutils
-import innvestigate.utils.keras as kutils
+from innvestigate.utils import keras as kutils
 from innvestigate.utils.keras import checks as kchecks
 from innvestigate.utils.keras import graph as kgraph
 from . import relevance_rule as rrule
@@ -84,54 +77,54 @@ class BaselineLRPZ(base.AnalyzerNetworkBase):
     def __init__(self, model, **kwargs):
         # Inside function to not break import if Keras changes.
         BASELINELRPZ_LAYERS = (
-            keras.engine.topology.InputLayer,
-            keras.layers.convolutional.Conv1D,
-            keras.layers.convolutional.Conv2D,
-            keras.layers.convolutional.Conv2DTranspose,
-            keras.layers.convolutional.Conv3D,
-            keras.layers.convolutional.Conv3DTranspose,
-            keras.layers.convolutional.Cropping1D,
-            keras.layers.convolutional.Cropping2D,
-            keras.layers.convolutional.Cropping3D,
-            keras.layers.convolutional.SeparableConv1D,
-            keras.layers.convolutional.SeparableConv2D,
-            keras.layers.convolutional.UpSampling1D,
-            keras.layers.convolutional.UpSampling2D,
-            keras.layers.convolutional.UpSampling3D,
-            keras.layers.convolutional.ZeroPadding1D,
-            keras.layers.convolutional.ZeroPadding2D,
-            keras.layers.convolutional.ZeroPadding3D,
-            keras.layers.core.Activation,
-            keras.layers.core.ActivityRegularization,
-            keras.layers.core.Dense,
-            keras.layers.core.Dropout,
-            keras.layers.core.Flatten,
-            keras.layers.core.Lambda,
-            keras.layers.core.Masking,
-            keras.layers.core.Permute,
-            keras.layers.core.RepeatVector,
-            keras.layers.core.Reshape,
-            keras.layers.core.SpatialDropout1D,
-            keras.layers.core.SpatialDropout2D,
-            keras.layers.core.SpatialDropout3D,
-            keras.layers.local.LocallyConnected1D,
-            keras.layers.local.LocallyConnected2D,
-            keras.layers.Add,
-            keras.layers.Concatenate,
-            keras.layers.Dot,
-            keras.layers.Maximum,
-            keras.layers.Minimum,
-            keras.layers.Subtract,
-            keras.layers.noise.AlphaDropout,
-            keras.layers.noise.GaussianDropout,
-            keras.layers.noise.GaussianNoise,
-            keras.layers.normalization.BatchNormalization,
-            keras.layers.pooling.GlobalMaxPooling1D,
-            keras.layers.pooling.GlobalMaxPooling2D,
-            keras.layers.pooling.GlobalMaxPooling3D,
-            keras.layers.pooling.MaxPooling1D,
-            keras.layers.pooling.MaxPooling2D,
-            keras.layers.pooling.MaxPooling3D,
+            tensorflow.keras.layers.InputLayer,
+            tensorflow.keras.layers.Conv1D,
+            tensorflow.keras.layers.Conv2D,
+            tensorflow.keras.layers.Conv2DTranspose,
+            tensorflow.keras.layers.Conv3D,
+            tensorflow.keras.layers.Conv3DTranspose,
+            tensorflow.keras.layers.Cropping1D,
+            tensorflow.keras.layers.Cropping2D,
+            tensorflow.keras.layers.Cropping3D,
+            tensorflow.keras.layers.SeparableConv1D,
+            tensorflow.keras.layers.SeparableConv2D,
+            tensorflow.keras.layers.UpSampling1D,
+            tensorflow.keras.layers.UpSampling2D,
+            tensorflow.keras.layers.UpSampling3D,
+            tensorflow.keras.layers.ZeroPadding1D,
+            tensorflow.keras.layers.ZeroPadding2D,
+            tensorflow.keras.layers.ZeroPadding3D,
+            tensorflow.keras.layers.Activation,
+            tensorflow.keras.layers.ActivityRegularization,
+            tensorflow.keras.layers.Dense,
+            tensorflow.keras.layers.Dropout,
+            tensorflow.keras.layers.Flatten,
+            tensorflow.keras.layers.Lambda,
+            tensorflow.keras.layers.Masking,
+            tensorflow.keras.layers.Permute,
+            tensorflow.keras.layers.RepeatVector,
+            tensorflow.keras.layers.Reshape,
+            tensorflow.keras.layers.SpatialDropout1D,
+            tensorflow.keras.layers.SpatialDropout2D,
+            tensorflow.keras.layers.SpatialDropout3D,
+            tensorflow.keras.layers.LocallyConnected1D,
+            tensorflow.keras.layers.LocallyConnected2D,
+            tensorflow.keras.layers.Add,
+            tensorflow.keras.layers.Concatenate,
+            tensorflow.keras.layers.Dot,
+            tensorflow.keras.layers.Maximum,
+            tensorflow.keras.layers.Minimum,
+            tensorflow.keras.layers.Subtract,
+            tensorflow.keras.layers.AlphaDropout,
+            tensorflow.keras.layers.GaussianDropout,
+            tensorflow.keras.layers.GaussianNoise,
+            tensorflow.keras.layers.BatchNormalization,
+            tensorflow.keras.layers.GlobalMaxPooling1D,
+            tensorflow.keras.layers.GlobalMaxPooling2D,
+            tensorflow.keras.layers.GlobalMaxPooling3D,
+            tensorflow.keras.layers.MaxPooling1D,
+            tensorflow.keras.layers.MaxPooling2D,
+            tensorflow.keras.layers.MaxPooling3D,
         )
 
         self._add_model_softmax_check()
@@ -153,7 +146,7 @@ class BaselineLRPZ(base.AnalyzerNetworkBase):
                               if x not in stop_analysis_at_tensors]
         gradients = iutils.to_list(ilayers.Gradient()(
             tensors_to_analyze+[model.outputs[0]]))
-        return [keras.layers.Multiply()([i, g])
+        return [tensorflow.keras.layers.Multiply()([i, g])
                 for i, g in zip(tensors_to_analyze, gradients)]
 
 
@@ -231,9 +224,9 @@ class BatchNormalizationReverseLayer(kgraph.ReverseMappingBase):
         # multiplication and then addition. The multiplicative scaling layer
         # has no effect on LRP and functions as a linear activation layer
 
-        minus_mu = keras.layers.Lambda(lambda x: x - K.reshape(self._mean, broadcast_shape))
-        minus_beta = keras.layers.Lambda(lambda x: x - K.reshape(self._beta, broadcast_shape))
-        prepare_div = keras.layers.Lambda(lambda x: x + (K.cast(K.greater_equal(x,0), K.floatx())*2-1)*K.epsilon())
+        minus_mu = tensorflow.keras.layers.Lambda(lambda x: x - K.reshape(self._mean, broadcast_shape))
+        minus_beta = tensorflow.keras.layers.Lambda(lambda x: x - K.reshape(self._beta, broadcast_shape))
+        prepare_div = tensorflow.keras.layers.Lambda(lambda x: x + (K.cast(K.greater_equal(x,0), K.floatx())*2-1)*K.epsilon())
 
 
         x_minus_mu = kutils.apply(minus_mu, Xs)
@@ -242,9 +235,9 @@ class BatchNormalizationReverseLayer(kgraph.ReverseMappingBase):
         else:
             y_minus_beta = Ys
 
-        numerator = [keras.layers.Multiply()([x, ymb, r])
+        numerator = [tensorflow.keras.layers.Multiply()([x, ymb, r])
                      for x, ymb, r in zip(Xs, y_minus_beta, Rs)]
-        denominator = [keras.layers.Multiply()([xmm, y])
+        denominator = [tensorflow.keras.layers.Multiply()([xmm, y])
                        for xmm, y in zip(x_minus_mu, Ys)]
 
         return [ilayers.SafeDivide()([n, prepare_div(d)])
@@ -278,7 +271,7 @@ class AddReverseLayer(kgraph.ReverseMappingBase):
         # using the gradient.
         tmp = iutils.to_list(grad(Xs+Zs+tmp))
         # Re-weight relevance with the input values.
-        return [keras.layers.Multiply()([a, b])
+        return [tensorflow.keras.layers.Multiply()([a, b])
                 for a, b in zip(Xs, tmp)]
 
 
@@ -310,7 +303,7 @@ class AveragePoolingReverseLayer(kgraph.ReverseMappingBase):
         # using the gradient.
         tmp = iutils.to_list(grad(Xs+Zs+tmp))
         # Re-weight relevance with the input values.
-        return [keras.layers.Multiply()([a, b])
+        return [tensorflow.keras.layers.Multiply()([a, b])
                 for a, b in zip(Xs, tmp)]
 
 
@@ -455,9 +448,9 @@ class LRP(base.ReverseAnalyzerBase):
 
     def _default_reverse_mapping(self, Xs, Ys, reversed_Ys, reverse_state):
         ##print("    in _default_reverse_mapping:", reverse_state['layer'].__class__.__name__, '(nid: {})'.format(reverse_state['nid']),  end='->')
-        #default_return_layers = [keras.layers.Activation]# TODO extend
+        #default_return_layers = [tensorflow.keras.layers.Activation]# TODO extend
         if(len(Xs) == len(Ys) and
-           isinstance(reverse_state['layer'], (keras.layers.Activation,)) and
+           isinstance(reverse_state['layer'], (tensorflow.keras.layers.Activation,)) and
            all([K.int_shape(x) == K.int_shape(y) for x, y in zip(Xs, Ys)])):
             # Expect Xs and Ys to have the same shapes.
             # There is not mixing of relevances as there is kernel,

--- a/innvestigate/analyzer/relevance_based/relevance_rule.py
+++ b/innvestigate/analyzer/relevance_based/relevance_rule.py
@@ -8,23 +8,16 @@ from builtins import zip
 ###############################################################################
 ###############################################################################
 
-import keras
-import keras.backend as K
-import keras.engine.topology
-import keras.models
-import keras.layers
-import keras.layers.convolutional
-import keras.layers.core
-import keras.layers.local
-import keras.layers.noise
-import keras.layers.normalization
-import keras.layers.pooling
+import tensorflow.keras
+import tensorflow.keras.backend as K
+import tensorflow.keras.models
+import tensorflow.keras.layers
 import numpy as np
 
 
 from innvestigate import layers as ilayers
 from innvestigate import utils as iutils
-import innvestigate.utils.keras as kutils
+from innvestigate.utils import keras as kutils
 from innvestigate.utils.keras import backend as iK
 from innvestigate.utils.keras import graph as kgraph
 from . import utils as rutils
@@ -85,7 +78,7 @@ class ZRule(kgraph.ReverseMappingBase):
         # using the gradient.
         tmp = iutils.to_list(grad(Xs+Zs+tmp))
         # Re-weight relevance with the input values.
-        return [keras.layers.Multiply()([a, b])
+        return [tensorflow.keras.layers.Multiply()([a, b])
                 for a, b in zip(Xs, tmp)]
 
 
@@ -119,7 +112,7 @@ class EpsilonRule(kgraph.ReverseMappingBase):
     def apply(self, Xs, Ys, Rs, reverse_state):
         grad = ilayers.GradientWRT(len(Xs))
         # The epsilon rule aligns epsilon with the (extended) sign: 0 is considered to be positive
-        prepare_div = keras.layers.Lambda(lambda x: x + (K.cast(K.greater_equal(x,0), K.floatx())*2-1)*self._epsilon)
+        prepare_div = tensorflow.keras.layers.Lambda(lambda x: x + (K.cast(K.greater_equal(x,0), K.floatx())*2-1)*self._epsilon)
 
         # Get activations.
         Zs = kutils.apply(self._layer_wo_act, Xs)
@@ -131,7 +124,7 @@ class EpsilonRule(kgraph.ReverseMappingBase):
         # using the gradient.
         tmp = iutils.to_list(grad(Xs+Zs+tmp))
         # Re-weight relevance with the input values.
-        return [keras.layers.Multiply()([a, b])
+        return [tensorflow.keras.layers.Multiply()([a, b])
                 for a, b in zip(Xs, tmp)]
 
 
@@ -270,17 +263,17 @@ class AlphaBetaRule(kgraph.ReverseMappingBase):
     def apply(self, Xs, Ys, Rs, reverse_state):
         #this method is correct, but wasteful
         grad = ilayers.GradientWRT(len(Xs))
-        times_alpha = keras.layers.Lambda(lambda x: x * self._alpha)
-        times_beta = keras.layers.Lambda(lambda x: x * self._beta)
-        keep_positives = keras.layers.Lambda(lambda x: x * K.cast(K.greater(x,0), K.floatx()))
-        keep_negatives = keras.layers.Lambda(lambda x: x * K.cast(K.less(x,0), K.floatx()))
+        times_alpha = tensorflow.keras.layers.Lambda(lambda x: x * self._alpha)
+        times_beta = tensorflow.keras.layers.Lambda(lambda x: x * self._beta)
+        keep_positives = tensorflow.keras.layers.Lambda(lambda x: x * K.cast(K.greater(x,0), K.floatx()))
+        keep_negatives = tensorflow.keras.layers.Lambda(lambda x: x * K.cast(K.less(x,0), K.floatx()))
 
 
         def f(layer1, layer2, X1, X2):
             # Get activations of full positive or negative part.
             Z1 = kutils.apply(layer1, X1)
             Z2 = kutils.apply(layer2, X2)
-            Zs = [keras.layers.Add()([a, b])
+            Zs = [tensorflow.keras.layers.Add()([a, b])
                     for a, b in zip(Z1, Z2)]
             # Divide incoming relevance by the activations.
             tmp = [ilayers.SafeDivide()([a, b])
@@ -290,12 +283,12 @@ class AlphaBetaRule(kgraph.ReverseMappingBase):
             tmp1 = iutils.to_list(grad(X1+Z1+tmp))
             tmp2 = iutils.to_list(grad(X2+Z2+tmp))
             # Re-weight relevance with the input values.
-            tmp1 = [keras.layers.Multiply()([a, b])
+            tmp1 = [tensorflow.keras.layers.Multiply()([a, b])
                     for a, b in zip(X1, tmp1)]
-            tmp2 = [keras.layers.Multiply()([a, b])
+            tmp2 = [tensorflow.keras.layers.Multiply()([a, b])
                     for a, b in zip(X2, tmp2)]
             #combine and return
-            return [keras.layers.Add()([a, b])
+            return [tensorflow.keras.layers.Add()([a, b])
                     for a, b in zip(tmp1, tmp2)]
 
 
@@ -312,7 +305,7 @@ class AlphaBetaRule(kgraph.ReverseMappingBase):
             inhibitor_relevances = f(self._layer_wo_act_negative,
                                      self._layer_wo_act_positive,
                                      Xs_pos, Xs_neg)
-            return [keras.layers.Subtract()([times_alpha(a), times_beta(b)])
+            return [tensorflow.keras.layers.Subtract()([times_alpha(a), times_beta(b)])
                         for a, b in zip(activator_relevances, inhibitor_relevances)]
         else:
             return activator_relevances
@@ -412,8 +405,8 @@ class BoundedRule(kgraph.ReverseMappingBase):
     # TODO: clean up this implementation and add more documentation
     def apply(self, Xs, Ys, Rs, reverse_state):
         grad = ilayers.GradientWRT(len(Xs))
-        to_low = keras.layers.Lambda(lambda x: x * 0 + self._low)
-        to_high = keras.layers.Lambda(lambda x: x * 0 + self._high)
+        to_low = tensorflow.keras.layers.Lambda(lambda x: x * 0 + self._low)
+        to_high = tensorflow.keras.layers.Lambda(lambda x: x * 0 + self._high)
 
         low = [to_low(x) for x in Xs]
         high = [to_high(x) for x in Xs]
@@ -422,7 +415,7 @@ class BoundedRule(kgraph.ReverseMappingBase):
         A = kutils.apply(self._layer_wo_act, Xs)
         B = kutils.apply(self._layer_wo_act_positive, low)
         C = kutils.apply(self._layer_wo_act_negative, high)
-        Zs = [keras.layers.Subtract()([a, keras.layers.Add()([b, c])])
+        Zs = [tensorflow.keras.layers.Subtract()([a, tensorflow.keras.layers.Add()([b, c])])
               for a, b, c in zip(A, B, C)]
 
         # Divide relevances with the value.
@@ -433,11 +426,11 @@ class BoundedRule(kgraph.ReverseMappingBase):
         tmpB = iutils.to_list(grad(low+B+tmp))
         tmpC = iutils.to_list(grad(high+C+tmp))
 
-        tmpA = [keras.layers.Multiply()([a, b]) for a, b in zip(Xs, tmpA)]
-        tmpB = [keras.layers.Multiply()([a, b]) for a, b in zip(low, tmpB)]
-        tmpC = [keras.layers.Multiply()([a, b]) for a, b in zip(high, tmpC)]
+        tmpA = [tensorflow.keras.layers.Multiply()([a, b]) for a, b in zip(Xs, tmpA)]
+        tmpB = [tensorflow.keras.layers.Multiply()([a, b]) for a, b in zip(low, tmpB)]
+        tmpC = [tensorflow.keras.layers.Multiply()([a, b]) for a, b in zip(high, tmpC)]
 
-        tmp = [keras.layers.Subtract()([a, keras.layers.Add()([b, c])])
+        tmp = [tensorflow.keras.layers.Subtract()([a, tensorflow.keras.layers.Add()([b, c])])
                for a, b, c in zip(tmpA, tmpB, tmpC)]
 
         return tmp
@@ -489,7 +482,7 @@ class ZPlusFastRule(kgraph.ReverseMappingBase):
         grad = ilayers.GradientWRT(len(Xs))
 
         #TODO: assert all inputs are positive, instead of only keeping the positives.
-        #keep_positives = keras.layers.Lambda(lambda x: x * K.cast(K.greater(x,0), K.floatx()))
+        #keep_positives = tensorflow.keras.layers.Lambda(lambda x: x * K.cast(K.greater(x,0), K.floatx()))
         #Xs = kutils.apply(keep_positives, Xs)
 
         # Get activations.
@@ -501,5 +494,5 @@ class ZPlusFastRule(kgraph.ReverseMappingBase):
         # using the gradient.
         tmp = iutils.to_list(grad(Xs+Zs+tmp))
         # Re-weight relevance with the input values.
-        return [keras.layers.Multiply()([a, b])
+        return [tensorflow.keras.layers.Multiply()([a, b])
                 for a, b in zip(Xs, tmp)]

--- a/innvestigate/analyzer/wrapper.py
+++ b/innvestigate/analyzer/wrapper.py
@@ -9,8 +9,8 @@ from builtins import zip
 ###############################################################################
 
 
-import keras.models
-import keras.backend as K
+import tensorflow.keras.models
+import tensorflow.keras.backend as K
 import numpy as np
 
 
@@ -97,7 +97,7 @@ class AugmentReduceBase(WrapperBase):
                                                 *args, **kwargs)
 
         if isinstance(self._subanalyzer, base.AnalyzerNetworkBase):
-            # Take the keras analyzer model and
+            # Take the tensorflow.keras analyzer model and
             # add augment and reduce functionality.
             self._keras_based_augment_reduce = True
         else:
@@ -134,7 +134,7 @@ class AugmentReduceBase(WrapperBase):
         new_outputs = iutils.to_list(self._reduce(tmp))
         new_constant_inputs = self._keras_get_constant_inputs()
 
-        new_model = keras.models.Model(
+        new_model = tensorflow.keras.models.Model(
             inputs=inputs+extra_inputs+new_constant_inputs,
             outputs=new_outputs+extra_outputs)
         self._subanalyzer._analyzer_model = new_model
@@ -270,7 +270,7 @@ class PathIntegrator(AugmentReduceBase):
     def _keras_set_constant_inputs(self, inputs):
         tmp = [K.variable(x) for x in inputs]
         self._keras_constant_inputs = [
-            keras.layers.Input(tensor=x, shape=x.shape[1:])
+            tensorflow.keras.layers.Input(tensor=x, shape=x.shape[1:])
             for x in tmp]
 
     def _keras_get_constant_inputs(self):
@@ -283,7 +283,7 @@ class PathIntegrator(AugmentReduceBase):
             self._keras_set_constant_inputs(tmp)
 
         reference_inputs = self._keras_get_constant_inputs()
-        return [keras.layers.Subtract()([x, ri])
+        return [tensorflow.keras.layers.Subtract()([x, ri])
                 for x, ri in zip(X, reference_inputs)]
 
     def _augment(self, X):
@@ -304,8 +304,7 @@ class PathIntegrator(AugmentReduceBase):
             axis=1)
         path_steps = [multiply_with_linspace(d) for d in difference]
 
-        reference_inputs = self._keras_get_constant_inputs()
-        ret = [keras.layers.Add()([x, p]) for x, p in zip(reference_inputs, path_steps)]
+        ret = [tensorflow.keras.layers.Add()([x, p]) for x, p in zip(tmp, path_steps)]
         ret = [ilayers.Reshape((-1,)+K.int_shape(x)[2:])(x) for x in ret]
         return ret
 
@@ -314,7 +313,7 @@ class PathIntegrator(AugmentReduceBase):
         difference = self._keras_difference
         del self._keras_difference
 
-        return [keras.layers.Multiply()([x, d])
+        return [tensorflow.keras.layers.Multiply()([x, d])
                 for x, d in zip(tmp, difference)]
 
     def _get_state(self):

--- a/innvestigate/applications/imagenet.py
+++ b/innvestigate/applications/imagenet.py
@@ -1,7 +1,7 @@
 """Example applications for image classifcation.
 
 Each function returns a pretrained ImageNet model.
-The models are based on keras.applications models and
+The models are based on tensorflow.keras.applications models and
 contain additionally pretrained patterns.
 
 The returned dictionary contains the following
@@ -26,15 +26,15 @@ from builtins import range
 ###############################################################################
 
 
-import keras.backend as K
-import keras.applications.resnet50
-import keras.applications.vgg16
-import keras.applications.vgg19
-import keras.applications.inception_v3
-import keras.applications.inception_resnet_v2
-import keras.applications.densenet
-import keras.applications.nasnet
-import keras.utils.data_utils
+import tensorflow.keras.backend as K
+import tensorflow.keras.applications.resnet50
+import tensorflow.keras.applications.vgg16
+import tensorflow.keras.applications.vgg19
+import tensorflow.keras.applications.inception_v3
+import tensorflow.keras.applications.inception_resnet_v2
+import tensorflow.keras.applications.densenet
+import tensorflow.keras.applications.nasnet
+import tensorflow.keras.utils.data_utils
 import numpy as np
 import warnings
 
@@ -89,7 +89,7 @@ def _get_patterns_info(netname, pattern_type):
 ###############################################################################
 
 
-def _prepare_keras_net(netname,
+def _prepare_tensorflow.keras_net(netname,
                        clazz,
                        image_shape,
                        preprocess_f,
@@ -133,7 +133,7 @@ def _prepare_keras_net(netname,
         except KeyError:
             warnings.warn("There are no patterns for network '%s'." % netname)
         else:
-            patterns_path = keras.utils.data_utils.get_file(
+            patterns_path = tensorflow.keras.utils.data_utils.get_file(
                 pattern_info["file_name"],
                 pattern_info["url"],
                 cache_subdir="innvestigate_patterns",
@@ -152,11 +152,11 @@ def _prepare_keras_net(netname,
 
 
 def vgg16(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "vgg16",
-        keras.applications.vgg16.VGG16,
+        tensorflow.keras.applications.vgg16.VGG16,
         [224, 224],
-        preprocess_f=keras.applications.vgg16.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.vgg16.preprocess_input,
         preprocess_mode="caffe",
         color_coding="BGR",
         load_weights=load_weights,
@@ -164,11 +164,11 @@ def vgg16(load_weights=False, load_patterns=False):
 
 
 def vgg19(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "vgg19",
-        keras.applications.vgg19.VGG19,
+        tensorflow.keras.applications.vgg19.VGG19,
         [224, 224],
-        preprocess_f=keras.applications.vgg19.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.vgg19.preprocess_input,
         preprocess_mode="caffe",
         color_coding="BGR",
         load_weights=load_weights,
@@ -181,11 +181,11 @@ def vgg19(load_weights=False, load_patterns=False):
 
 
 def resnet50(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "resnet50",
-        keras.applications.resnet50.ResNet50,
+        tensorflow.keras.applications.resnet50.ResNet50,
         [224, 224],
-        preprocess_f=keras.applications.resnet50.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.resnet50.preprocess_input,
         preprocess_mode="caffe",
         color_coding="BGR",
         load_weights=load_weights,
@@ -198,11 +198,11 @@ def resnet50(load_weights=False, load_patterns=False):
 
 
 def inception_v3(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "inception_v3",
-        keras.applications.inception_v3.InceptionV3,
+        tensorflow.keras.applications.inception_v3.InceptionV3,
         [299, 299],
-        preprocess_f=keras.applications.inception_v3.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.inception_v3.preprocess_input,
         preprocess_mode="tf",
         load_weights=load_weights,
         load_patterns=load_patterns)
@@ -214,11 +214,11 @@ def inception_v3(load_weights=False, load_patterns=False):
 
 
 def inception_resnet_v2(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "inception_resnet_v2",
-        keras.applications.inception_resnet_v2.InceptionResNetV2,
+        tensorflow.keras.applications.inception_resnet_v2.InceptionResNetV2,
         [299, 299],
-        preprocess_f=keras.applications.inception_resnet_v2.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.inception_resnet_v2.preprocess_input,
         preprocess_mode="tf",
         load_weights=load_weights,
         load_patterns=load_patterns)
@@ -230,33 +230,33 @@ def inception_resnet_v2(load_weights=False, load_patterns=False):
 
 
 def densenet121(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "densenet121",
-        keras.applications.densenet.DenseNet121,
+        tensorflow.keras.applications.densenet.DenseNet121,
         [224, 224],
-        preprocess_f=keras.applications.densenet.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.densenet.preprocess_input,
         preprocess_mode="torch",
         load_weights=load_weights,
         load_patterns=load_patterns)
 
 
 def densenet169(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "densenet169",
-        keras.applications.densenet.DenseNet169,
+        tensorflow.keras.applications.densenet.DenseNet169,
         [224, 224],
-        preprocess_f=keras.applications.densenet.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.densenet.preprocess_input,
         preprocess_mode="torch",
         load_weights=load_weights,
         load_patterns=load_patterns)
 
 
 def densenet201(load_weights=False, load_patterns=False):
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "densenet201",
-        keras.applications.densenet.DenseNet201,
+        tensorflow.keras.applications.densenet.DenseNet201,
         [224, 224],
-        preprocess_f=keras.applications.densenet.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.densenet.preprocess_input,
         preprocess_mode="torch",
         load_weights=load_weights,
         load_patterns=load_patterns)
@@ -271,12 +271,12 @@ def nasnet_large(load_weights=False, load_patterns=False):
     if K.image_data_format() == "channels_first":
         raise Exception("NASNet is not available for channels first.")
 
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "nasnet_large",
-        keras.applications.nasnet.NASNetLarge,
+        tensorflow.keras.applications.nasnet.NASNetLarge,
         [331, 331],
         color_coding="BGR",
-        preprocess_f=keras.applications.nasnet.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.nasnet.preprocess_input,
         preprocess_mode="tf",
         load_weights=load_weights,
         load_patterns=load_patterns)
@@ -286,12 +286,12 @@ def nasnet_mobile(load_weights=False, load_patterns=False):
     if K.image_data_format() == "channels_first":
         raise Exception("NASNet is not available for channels first.")
 
-    return _prepare_keras_net(
+    return _prepare_tensorflow.keras_net(
         "nasnet_mobile",
-        keras.applications.nasnet.NASNetMobile,
+        tensorflow.keras.applications.nasnet.NASNetMobile,
         [224, 224],
         color_coding="BGR",
-        preprocess_f=keras.applications.nasnet.preprocess_input,
+        preprocess_f=tensorflow.keras.applications.nasnet.preprocess_input,
         preprocess_mode="tf",
         load_weights=load_weights,
         load_patterns=load_patterns)

--- a/innvestigate/applications/mnist.py
+++ b/innvestigate/applications/mnist.py
@@ -18,12 +18,12 @@ from __future__ import\
 
 
 import os
-import keras.utils.data_utils
+import tensorflow.keras.utils.data_utils
 import numpy as np
 
-import keras.models
-from keras.models import load_model, clone_model
-#from keras.utils import get_file
+import tensorflow.keras.models
+from tensorflow.keras.models import load_model, clone_model
+#from tensorflow.keras.utils import get_file
 
 
 
@@ -76,20 +76,20 @@ def _load_pretrained_net(modelname, new_input_shape):
 
     model = load_model(model_path)
     #create replacement input layer with new shape.
-    model.layers[0] = keras.layers.InputLayer(input_shape=new_input_shape, name="input_1")
+    model.layers[0] = tensorflow.keras.layers.InputLayer(input_shape=new_input_shape, name="input_1")
     for l in model.layers:
         l.name = "%s_workaround" % l.name
-    model = keras.models.Sequential(layers=model.layers)
+    model = tensorflow.keras.models.Sequential(layers=model.layers)
 
     model_w_sm = clone_model(model)
 
-    #NOTE: perform forward pass to fix a keras 2.2.0 related issue with improper weight initialization
+    #NOTE: perform forward pass to fix a tensorflow.keras 2.2.0 related issue with improper weight initialization
     #See: https://github.com/albermax/innvestigate/issues/88
     x_dummy = np.zeros(new_input_shape)[None, ...]
     model_w_sm.predict(x_dummy)
 
     model_w_sm.set_weights(model.get_weights())
-    model_w_sm.add(keras.layers.Activation("softmax"))
+    model_w_sm.add(tensorflow.keras.layers.Activation("softmax"))
     return model, model_w_sm
 
 

--- a/innvestigate/layers.py
+++ b/innvestigate/layers.py
@@ -8,12 +8,12 @@ from builtins import range, zip
 ###############################################################################
 ###############################################################################
 
-import keras
-import keras.backend as K
-import keras.constraints
-import keras.layers
-import keras.regularizers
-from keras.utils import conv_utils
+import tensorflow.keras
+import tensorflow.keras.backend as K
+import tensorflow.keras.constraints
+import tensorflow.keras.layers
+import tensorflow.keras.regularizers
+from tensorflow.python.keras.utils import conv_utils
 import numpy as np
 
 
@@ -91,22 +91,22 @@ def One(reference=None):
     return Constant(1, reference=reference)
 
 
-class ZerosLike(keras.layers.Layer):
+class ZerosLike(tensorflow.keras.layers.Layer):
     def call(self, x):
         return [K.zeros_like(tmp) for tmp in iutils.to_list(x)]
 
 
-class OnesLike(keras.layers.Layer):
+class OnesLike(tensorflow.keras.layers.Layer):
     def call(self, x):
         return [K.ones_like(tmp) for tmp in iutils.to_list(x)]
 
 
-class AsFloatX(keras.layers.Layer):
+class AsFloatX(tensorflow.keras.layers.Layer):
     def call(self, x):
         return [iK.to_floatx(tmp) for tmp in iutils.to_list(x)]
 
 
-class FiniteCheck(keras.layers.Layer):
+class FiniteCheck(tensorflow.keras.layers.Layer):
     def call(self, x):
         return [K.sum(iK.to_floatx(iK.is_not_finite(tmp)))
                 for tmp in iutils.to_list(x)]
@@ -117,7 +117,7 @@ class FiniteCheck(keras.layers.Layer):
 ###############################################################################
 
 
-class Gradient(keras.layers.Layer):
+class Gradient(tensorflow.keras.layers.Layer):
     "Returns gradient of sum(output), expects inputs+[output,]."
 
     def call(self, x):
@@ -128,7 +128,7 @@ class Gradient(keras.layers.Layer):
         return input_shapes[:-1]
 
 
-class GradientWRT(keras.layers.Layer):
+class GradientWRT(tensorflow.keras.layers.Layer):
     "Returns gradient wrt to another layer and given gradient,"
     " expects inputs+[output,]."
 
@@ -156,11 +156,11 @@ class GradientWRT(keras.layers.Layer):
             return [x for c, x in zip(self.mask, input_shapes[:self.n_inputs])
                     if c]
 
-    # todo: remove once keras is fixed.
+    # todo: remove once tensorflow.keras is fixed.
     # this is a workaround for cases when
     # wrapper and skip connections are used together.
-    # bring the fix into keras and remove once
-    # keras is patched.
+    # bring the fix into tensorflow.keras and remove once
+    # tensorflow.keras is patched.
     def compute_mask(self, inputs, mask=None):
         """Computes an output mask tensor.
 
@@ -200,7 +200,7 @@ class GradientWRT(keras.layers.Layer):
 ###############################################################################
 
 
-class _Reduce(keras.layers.Layer):
+class _Reduce(tensorflow.keras.layers.Layer):
 
     def __init__(self, axis=-1, keepdims=False, *args, **kwargs):
         self.axis = axis
@@ -264,7 +264,7 @@ class CountNonZero(_Reduce):
 ###############################################################################
 
 
-class _Map(keras.layers.Layer):
+class _Map(tensorflow.keras.layers.Layer):
 
     def call(self, x):
         if isinstance(x, list) and len(x) == 1:
@@ -353,51 +353,51 @@ class Print(_Map):
 ###############################################################################
 
 
-class Greater(keras.layers.Layer):
+class Greater(tensorflow.keras.layers.Layer):
     def call(self, x):
         a, b = x
         return K.greater(a, b)
 
 
-class Less(keras.layers.Layer):
+class Less(tensorflow.keras.layers.Layer):
     def call(self, x):
         a, b = x
         return K.less(a, b)
 
 
-class GreaterThanZero(keras.layers.Layer):
+class GreaterThanZero(tensorflow.keras.layers.Layer):
     def call(self, x):
         return K.greater(x, K.constant(0))
 
 
-class LessThanZero(keras.layers.Layer):
+class LessThanZero(tensorflow.keras.layers.Layer):
     def call(self, x):
         return K.less(x, K.constant(0))
 
 
-class GreaterEqual(keras.layers.Layer):
+class GreaterEqual(tensorflow.keras.layers.Layer):
     def call(self, x):
         a, b = x
         return K.greater_equal(a, b)
 
 
-class LessEqual(keras.layers.Layer):
+class LessEqual(tensorflow.keras.layers.Layer):
     def call(self, x):
         a, b = x
         return K.less_equal(a, b)
 
 
-class GreaterEqualThanZero(keras.layers.Layer):
+class GreaterEqualThanZero(tensorflow.keras.layers.Layer):
     def call(self, x):
         return K.greater_equal(x, K.constant(0))
 
 
-class LessEqualThanZero(keras.layers.Layer):
+class LessEqualThanZero(tensorflow.keras.layers.Layer):
     def call(self, x):
         return K.less_equal(x, K.constant(0))
 
 
-class Transpose(keras.layers.Layer):
+class Transpose(tensorflow.keras.layers.Layer):
 
     def __init__(self, axes=None, **kwargs):
         self._axes = axes
@@ -416,7 +416,7 @@ class Transpose(keras.layers.Layer):
             return tuple(np.asarray(input_shape)[list(self._axes)])
 
 
-class Dot(keras.layers.Layer):
+class Dot(tensorflow.keras.layers.Layer):
 
     def call(self, x):
         a, b = x
@@ -426,7 +426,7 @@ class Dot(keras.layers.Layer):
         return (input_shapes[0][0], input_shapes[1][1])
 
 
-class Divide(keras.layers.Layer):
+class Divide(tensorflow.keras.layers.Layer):
 
     def call(self, x):
         a, b = x
@@ -436,7 +436,7 @@ class Divide(keras.layers.Layer):
         return input_shapes[0]
 
 
-class SafeDivide(keras.layers.Layer):
+class SafeDivide(tensorflow.keras.layers.Layer):
 
     def __init__(self, *args, **kwargs):
         factor = kwargs.pop("factor", None)
@@ -459,7 +459,7 @@ class SafeDivide(keras.layers.Layer):
 ###############################################################################
 
 
-class Repeat(keras.layers.Layer):
+class Repeat(tensorflow.keras.layers.Layer):
 
     def __init__(self, n, axis, *args, **kwargs):
         self._n = n
@@ -481,7 +481,7 @@ class Repeat(keras.layers.Layer):
             return (input_shape[0]*self._n,)+input_shape[1:]
 
 
-class Reshape(keras.layers.Layer):
+class Reshape(tensorflow.keras.layers.Layer):
 
     def __init__(self, shape, *args, **kwargs):
         self._shape = shape
@@ -494,7 +494,7 @@ class Reshape(keras.layers.Layer):
         return tuple(x if x >= 0 else None for x in self._shape)
 
 
-class MultiplyWithLinspace(keras.layers.Layer):
+class MultiplyWithLinspace(tensorflow.keras.layers.Layer):
 
     def __init__(self, start, end, n=1, axis=-1, *args, **kwargs):
         self._start = start
@@ -522,14 +522,14 @@ class MultiplyWithLinspace(keras.layers.Layer):
         return ret
 
 
-class TestPhaseGaussianNoise(keras.layers.GaussianNoise):
+class TestPhaseGaussianNoise(tensorflow.keras.layers.GaussianNoise):
 
     def call(self, inputs):
         # Always add Gaussian noise!
         return super(TestPhaseGaussianNoise, self).call(inputs, training=True)
 
 
-class ExtractConv2DPatches(keras.layers.Layer):
+class ExtractConv2DPatches(tensorflow.keras.layers.Layer):
 
     def __init__(self,
                  kernel_shape,
@@ -583,7 +583,7 @@ class ExtractConv2DPatches(keras.layers.Layer):
                 (np.product(self._kernel_shape) * self._depth,))
 
 
-class RunningMeans(keras.layers.Layer):
+class RunningMeans(tensorflow.keras.layers.Layer):
 
     def __init__(self, *args, **kwargs):
         self.stateful = True
@@ -630,7 +630,7 @@ class RunningMeans(keras.layers.Layer):
         return input_shapes
 
 
-class Broadcast(keras.layers.Layer):
+class Broadcast(tensorflow.keras.layers.Layer):
 
     def call(self, x):
         target_shapped, x = x
@@ -640,7 +640,7 @@ class Broadcast(keras.layers.Layer):
         return input_shapes[0]
 
 
-class Gather(keras.layers.Layer):
+class Gather(tensorflow.keras.layers.Layer):
 
     def call(self, inputs):
         x, index = inputs
@@ -650,7 +650,7 @@ class Gather(keras.layers.Layer):
         return (input_shapes[0][0], input_shapes[1][0])+input_shapes[0][2:]
 
 
-class GatherND(keras.layers.Layer):
+class GatherND(tensorflow.keras.layers.Layer):
 
     def call(self, inputs):
         x, indices = inputs

--- a/innvestigate/tests/analyzer/test_base.py
+++ b/innvestigate/tests/analyzer/test_base.py
@@ -60,7 +60,7 @@ def test_precommit__BasicGraphReversal():
 
 #     def method2(model):
 #         Create container execution
-#         model = keras.models.Model(inputs=model.inputs,
+#         model = tensorflow.keras.models.Model(inputs=model.inputs,
 #                                    outputs=model(model.inputs))
 #         return Gradient(model)
 
@@ -77,7 +77,7 @@ def test_precommit__BasicGraphReversal():
 
 #     def method2(model):
 #         Create container execution
-#         model = keras.models.Model(inputs=model.inputs,
+#         model = tensorflow.keras.models.Model(inputs=model.inputs,
 #                                    outputs=model(model.inputs))
 #         return Gradient(model)
 

--- a/innvestigate/tests/analyzer/test_deeplift.py
+++ b/innvestigate/tests/analyzer/test_deeplift.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.layers
-import keras.models
+import tensorflow.keras.layers
+import tensorflow.keras.models
 import numpy as np
 import pytest
 try:
@@ -51,13 +51,13 @@ def test_precommit__DeepLIFT():
 def test_precommit__DeepLIFT_Rescale():
 
     def method(model):
-        if keras.backend.image_data_format() == "channels_first":
+        if tensorflow.keras.backend.image_data_format() == "channels_first":
             input_shape = (1, 28, 28)
         else:
             input_shape = (28, 28, 1)
-        model = keras.models.Sequential([
-            keras.layers.Dense(10, input_shape=input_shape),
-            keras.layers.ReLU(),
+        model = tensorflow.keras.models.Sequential([
+            tensorflow.keras.layers.Dense(10, input_shape=input_shape),
+            tensorflow.keras.layers.ReLU(),
         ])
         return DeepLIFT(model)
 

--- a/innvestigate/tests/analyzer/test_init.py
+++ b/innvestigate/tests/analyzer/test_init.py
@@ -10,8 +10,8 @@ from __future__ import \
 
 import pytest
 
-import keras.layers
-import keras.models
+import tensorflow.keras.layers
+import tensorflow.keras.models
 
 from innvestigate import create_analyzer
 from innvestigate.analyzer import analyzers
@@ -26,8 +26,8 @@ from innvestigate.analyzer import analyzers
 @pytest.mark.precommit
 def test_fast__create_analyzers():
 
-    fake_model = keras.models.Sequential([
-        keras.layers.Dense(10, input_shape=(10,))
+    fake_model = tensorflow.keras.models.Sequential([
+        tensorflow.keras.layers.Dense(10, input_shape=(10,))
     ])
     for name in analyzers.keys():
         try:
@@ -44,8 +44,8 @@ def test_fast__create_analyzers():
 @pytest.mark.precommit
 def test_fast__create_analyzers_wrong_name():
 
-    fake_model = keras.models.Sequential([
-        keras.layers.Dense(10, input_shape=(10,))
+    fake_model = tensorflow.keras.models.Sequential([
+        tensorflow.keras.layers.Dense(10, input_shape=(10,))
     ])
     with pytest.raises(KeyError):
         create_analyzer("wrong name", fake_model)

--- a/innvestigate/tests/tools/test_pattern.py
+++ b/innvestigate/tests/tools/test_pattern.py
@@ -11,11 +11,11 @@ from __future__ import\
 import pytest
 
 
-from keras.datasets import mnist
-import keras.layers
-import keras.models
-from keras.models import Model
-import keras.optimizers
+from tensorflow.keras.datasets import mnist
+import tensorflow.keras.layers
+import tensorflow.keras.models
+from tensorflow.keras.models import Model
+import tensorflow.keras.optimizers
 import numpy as np
 import unittest
 
@@ -136,10 +136,10 @@ class HaufePatternExample(unittest.TestCase):
 
         X = y * a_s + eps * a_d
 
-        model = keras.models.Sequential(
-            [keras.layers.Dense(1, input_shape=(2,), use_bias=True), ]
+        model = tensorflow.keras.models.Sequential(
+            [tensorflow.keras.layers.Dense(1, input_shape=(2,), use_bias=True), ]
         )
-        model.compile(optimizer=keras.optimizers.Adam(lr=1), loss="mse")
+        model.compile(optimizer=tensorflow.keras.optimizers.Adam(lr=1), loss="mse")
         model.fit(X, y, epochs=20, verbose=0).history
         self.assertTrue(model.evaluate(X, y, verbose=0) < 0.05)
 
@@ -195,11 +195,11 @@ def train_model(model, data, epochs=20):
 
     x_train, y_train, x_test, y_test = data
     # convert class vectors to binary class matrices
-    y_train = keras.utils.to_categorical(y_train, num_classes)
-    y_test = keras.utils.to_categorical(y_test, num_classes)
+    y_train = tensorflow.keras.utils.to_categorical(y_train, num_classes)
+    y_test = tensorflow.keras.utils.to_categorical(y_test, num_classes)
 
     model.compile(loss='categorical_crossentropy',
-                  optimizer=keras.optimizers.RMSprop(),
+                  optimizer=tensorflow.keras.optimizers.RMSprop(),
                   metrics=['accuracy'])
 
     model.fit(x_train, y_train,

--- a/innvestigate/tests/tools/test_perturbate.py
+++ b/innvestigate/tests/tools/test_perturbate.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.layers
-import keras.models
+import tensorflow.keras.layers
+import tensorflow.keras.models
 import numpy as np
 import pytest
 
@@ -26,7 +26,7 @@ import innvestigate.utils as iutils
 @pytest.mark.precommit
 def test_fast__PerturbationAnalysis():
     # Some test data
-    if keras.backend.image_data_format() == "channels_first":
+    if tensorflow.keras.backend.image_data_format() == "channels_first":
         input_shape = (2, 1, 4, 4)
     else:
         input_shape = (2, 4, 4, 1)
@@ -34,9 +34,9 @@ def test_fast__PerturbationAnalysis():
     generator = iutils.BatchSequence([x, np.zeros(x.shape[0])], batch_size=x.shape[0])
 
     # Simple model
-    model = keras.models.Sequential([
-            keras.layers.Flatten(input_shape=x.shape[1:]),
-            keras.layers.Dense(1, use_bias=False),
+    model = tensorflow.keras.models.Sequential([
+            tensorflow.keras.layers.Flatten(input_shape=x.shape[1:]),
+            tensorflow.keras.layers.Dense(1, use_bias=False),
     ])
 
     weights = np.arange(4 * 4 * 1).reshape((4 * 4, 1))
@@ -66,7 +66,7 @@ def test_fast__PerturbationAnalysis():
 @pytest.mark.fast
 @pytest.mark.precommit
 def test_fast__Perturbation():
-    if keras.backend.image_data_format() == "channels_first":
+    if tensorflow.keras.backend.image_data_format() == "channels_first":
         input_shape = (1, 1, 4, 4)
     else:
         input_shape = (1, 4, 4, 1)
@@ -80,7 +80,7 @@ def test_fast__Perturbation():
     analysis[2:, 2:] = 3
     analysis = analysis.reshape(input_shape)
 
-    if keras.backend.image_data_format() == "channels_last":
+    if tensorflow.keras.backend.image_data_format() == "channels_last":
         x = np.moveaxis(x, 3, 1)
         analysis = np.moveaxis(analysis, 3, 1)
 

--- a/innvestigate/tests/utils/keras/test_graph.py
+++ b/innvestigate/tests/utils/keras/test_graph.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.models
+import tensorflow.keras.models
 import pytest
 
 
@@ -29,7 +29,7 @@ def test_fast__get_model_execution_graph():
 
     for network in networks.iterator(network_filter):
 
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
 
         graph = kgraph.get_model_execution_graph(model)
@@ -43,7 +43,7 @@ def test_commit__get_model_execution_graph():
 
     for network in networks.iterator(network_filter):
 
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
 
         graph = kgraph.get_model_execution_graph(model)
@@ -57,7 +57,7 @@ def test_precommit__get_model_execution_graph_resnet50():
 
     for network in networks.iterator(network_filter):
 
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
 
         graph = kgraph.get_model_execution_graph(model)
@@ -72,7 +72,7 @@ def test_fast__get_model_execution_graph_with_inputs():
 
     for network in networks.iterator(network_filter):
 
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
 
         graph = kgraph.get_model_execution_graph(model,

--- a/innvestigate/tests/utils/tests/test_layer.py
+++ b/innvestigate/tests/utils/tests/test_layer.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.layers
+import tensorflow.keras.layers
 import numpy as np
 import pytest
 
@@ -27,7 +27,7 @@ from innvestigate.utils.tests.layer import TestAnalysisHelper as AnalysisHelper
 @pytest.mark.precommit
 def test_fast__TestAnalysisHelper_one_layer():
 
-    layer = keras.layers.Dense(2, input_shape=(3,), use_bias=False)
+    layer = tensorflow.keras.layers.Dense(2, input_shape=(3,), use_bias=False)
     analyzer = Gradient
     weights = [np.asarray(((1, 2), (3, 4), (5, 6)))]
 
@@ -46,8 +46,8 @@ def test_fast__TestAnalysisHelper_one_layer():
 @pytest.mark.precommit
 def test_fast__TestAnalysisHelper_two_layers():
 
-    layers = [keras.layers.Dense(2, input_shape=(3,), use_bias=False),
-              keras.layers.Dense(2, use_bias=False)]
+    layers = [tensorflow.keras.layers.Dense(2, input_shape=(3,), use_bias=False),
+              tensorflow.keras.layers.Dense(2, use_bias=False)]
     analyzer = Gradient
     weights = [np.asarray(((1, 2), (3, 4), (5, 6))),
                np.asarray(((7, 8), (9, 1)))]

--- a/innvestigate/tools/pattern.py
+++ b/innvestigate/tools/pattern.py
@@ -10,11 +10,11 @@ import six
 ###############################################################################
 
 
-import keras.backend as K
-import keras.layers
-import keras.models
-import keras.optimizers
-import keras.utils
+import tensorflow.keras.backend as K
+import tensorflow.keras.layers
+import tensorflow.keras.models
+import tensorflow.keras.optimizers
+import tensorflow.keras.utils
 import numpy as np
 
 
@@ -113,7 +113,7 @@ def get_active_neuron_io(layer, active_node_indices,
         raise NotImplementedError("This code seems not to handle several Ys.")
         # Layer is applied several times in model.
         # Concatenate the io of the applications.
-        concatenate = keras.layers.Concatenate(axis=0)
+        concatenate = tensorflow.keras.layers.Concatenate(axis=0)
 
         if return_i and return_o:
             return (concatenate([x[0] for x in tmp]),
@@ -243,7 +243,7 @@ class LinearPattern(BasePattern):
 
         # Compute mask and active neuron counts.
         mask = ilayers.AsFloatX()(self._get_neuron_mask())
-        Y_masked = keras.layers.multiply([Y, mask])
+        Y_masked = tensorflow.keras.layers.multiply([Y, mask])
         count = ilayers.CountNonZero(axis=0)(mask)
         count_all = ilayers.Sum(axis=0)(ilayers.OnesLike()(mask))
 
@@ -265,7 +265,7 @@ class LinearPattern(BasePattern):
 
         # Create a dummy output to have a connected graph.
         # Needs to have the shape (mb_size, 1)
-        dummy = keras.layers.Average()([a, b, c])
+        dummy = tensorflow.keras.layers.Average()([a, b, c])
         return ilayers.Sum(axis=None)(dummy)
 
     def compute_pattern(self):
@@ -427,12 +427,12 @@ class PatternComputer(object):
         self._n_computer_outputs = len(computer_outputs)
         if self.compute_layers_in_parallel is True:
             self._computers = [
-                keras.models.Model(inputs=self.model.inputs,
+                tensorflow.keras.models.Model(inputs=self.model.inputs,
                                    outputs=computer_outputs)
             ]
         else:
             self._computers = [
-                keras.models.Model(inputs=self.model.inputs,
+                tensorflow.keras.models.Model(inputs=self.model.inputs,
                                    outputs=computer_output)
                 for computer_output in computer_outputs
             ]
@@ -440,7 +440,7 @@ class PatternComputer(object):
         # Distribute computation on more gpus.
         if self.gpus is not None and self.gpus > 1:
             raise NotImplementedError("Not supported yet.")
-            self._computers = [keras.utils.multi_gpu_model(tmp, gpus=self.gpus)
+            self._computers = [tensorflow.keras.utils.multi_gpu_model(tmp, gpus=self.gpus)
                                for tmp in self._computers]
 
     def compute(self, X, batch_size=32, verbose=0):
@@ -449,7 +449,7 @@ class PatternComputer(object):
 
         :param X: Data to compute patterns.
         :param batch_size: Batch size to use.
-        :param verbose: As for keras model.fit.
+        :param verbose: As for tensorflow.keras model.fit.
         """
         generator = iutils.BatchSequence(X, batch_size)
         return self.compute_generator(generator, verbose=verbose)
@@ -459,12 +459,12 @@ class PatternComputer(object):
         Compute and return the patterns for the model and the data `X`.
 
         :param generator: Data to compute patterns.
-        :param kwargs: Same as for keras model.fit_generator.
+        :param kwargs: Same as for tensorflow.keras model.fit_generator.
         """
         self._create_computers()
 
         # We don't do gradient updates.
-        class NoOptimizer(keras.optimizers.Optimizer):
+        class NoOptimizer(tensorflow.keras.optimizers.Optimizer):
             def get_updates(self, *args, **kwargs):
                 return []
         optimizer = NoOptimizer()
@@ -486,7 +486,7 @@ class PatternComputer(object):
             dummy = np.ones(shape=(n, 1), dtype=dtype)
             return [dummy for _ in range(n_dummy_outputs)]
 
-        if isinstance(generator, keras.utils.Sequence):
+        if isinstance(generator, tensorflow.keras.utils.Sequence):
             generator = iutils.TargetAugmentedSequence(generator,
                                                        get_dummy_targets)
         else:

--- a/innvestigate/tools/perturbate.py
+++ b/innvestigate/tools/perturbate.py
@@ -8,9 +8,9 @@ import numpy as np
 import warnings
 import time
 
-import keras.backend as K
-from keras.utils import Sequence
-from keras.utils.data_utils import OrderedEnqueuer, GeneratorEnqueuer
+import tensorflow.keras.backend as K
+from tensorflow.keras.utils import Sequence
+from tensorflow.python.keras.utils import OrderedEnqueuer, GeneratorEnqueuer
 
 import innvestigate.utils
 
@@ -191,7 +191,7 @@ class PerturbationAnalysis:
     :param analyzer: Analyzer.
     :type analyzer: innvestigate.analyzer.base.AnalyzerBase
     :param model: Trained Keras model.
-    :type model: keras.engine.training.Model
+    :type model: tensorflow.keras.engine.training.Model
     :param generator: Data generator.
     :type generator: innvestigate.utils.BatchSequence
     :param perturbation: Instance of Perturbation class that performs the perturbation.
@@ -278,7 +278,7 @@ class PerturbationAnalysis:
 
         The generator should return the same kind of data
         as accepted by `test_on_batch`.
-        For documentation, refer to keras.engine.training.evaluate_generator (https://keras.io/models/model/)
+        For documentation, refer to tensorflow.keras.engine.training.evaluate_generator (https://tensorflow.keras.io/models/model/)
         """
 
         steps_done = 0
@@ -290,16 +290,16 @@ class PerturbationAnalysis:
             warnings.warn(
                 UserWarning('Using a generator with `use_multiprocessing=True`'
                             ' and multiple workers may duplicate your data.'
-                            ' Please consider using the`keras.utils.Sequence'
+                            ' Please consider using the`tensorflow.keras.utils.Sequence'
                             ' class.'))
         if steps is None:
             if is_sequence:
                 steps = len(generator)
             else:
                 raise ValueError('`steps=None` is only valid for a generator'
-                                 ' based on the `keras.utils.Sequence` class.'
+                                 ' based on the `tensorflow.keras.utils.Sequence` class.'
                                  ' Please specify `steps` or use the'
-                                 ' `keras.utils.Sequence` class.')
+                                 ' `tensorflow.keras.utils.Sequence` class.')
         enqueuer = None
 
         try:

--- a/innvestigate/utils/__init__.py
+++ b/innvestigate/utils/__init__.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.backend as K
-import keras.utils
+import tensorflow.keras.backend as K
+import tensorflow.keras.utils
 import math
 
 
@@ -55,7 +55,7 @@ def to_list(l):
 ###############################################################################
 
 
-class BatchSequence(keras.utils.Sequence):
+class BatchSequence(tensorflow.keras.utils.Sequence):
     """Batch sequence generator.
 
     Take a (list of) input tensors and a batch size
@@ -88,7 +88,7 @@ class BatchSequence(keras.utils.Sequence):
             return tuple(ret)
 
 
-class TargetAugmentedSequence(keras.utils.Sequence):
+class TargetAugmentedSequence(tensorflow.keras.utils.Sequence):
     """Augments a sequence with a target on the fly.
 
     Takes a sequence/generator and a function that

--- a/innvestigate/utils/keras/__init__.py
+++ b/innvestigate/utils/keras/__init__.py
@@ -9,7 +9,7 @@ from builtins import zip
 ###############################################################################
 
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 import numpy as np
 
 
@@ -38,7 +38,6 @@ def apply(layer, inputs):
     :param layer: A Keras layer instance.
     :param inputs: A list of input tensors or a single tensor.
     """
-
     if isinstance(inputs, list) and len(inputs) > 1:
         try:
             ret = layer(inputs)
@@ -46,6 +45,8 @@ def apply(layer, inputs):
             # layer expects a single tensor.
             if len(inputs) != 1:
                 raise ValueError("Layer expects only a single input!")
+            ret = layer(inputs[0])
+
             ret = layer(inputs[0])
     else:
         ret = layer(inputs[0])
@@ -56,7 +57,7 @@ def apply(layer, inputs):
 def broadcast_np_tensors_to_keras_tensors(keras_tensors, np_tensors):
     """Broadcasts numpy tensors to the shape of Keras tensors.
 
-    :param keras_tensors: The Keras tensors with the target shapes.
+    :param tensorflow.keras_tensors: The Keras tensors with the target shapes.
     :param np_tensors: Numpy tensors that should be broadcasted.
     :return: The broadcasted Numpy tensors.
     """

--- a/innvestigate/utils/keras/backend.py
+++ b/innvestigate/utils/keras/backend.py
@@ -9,7 +9,7 @@ from builtins import zip
 ###############################################################################
 
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 
 
 __all__ = [

--- a/innvestigate/utils/keras/checks.py
+++ b/innvestigate/utils/keras/checks.py
@@ -9,21 +9,8 @@ from __future__ import\
 
 
 import inspect
-import keras.engine.topology
-import keras.layers
-import keras.layers.advanced_activations
-import keras.layers.convolutional
-import keras.layers.convolutional_recurrent
-import keras.layers.core
-import keras.layers.cudnn_recurrent
-import keras.layers.embeddings
-import keras.layers.local
-import keras.layers.noise
-import keras.layers.normalization
-import keras.layers.pooling
-import keras.layers.recurrent
-import keras.layers.wrappers
-import keras.legacy.layers
+# import tensorflow.keras.engine.topology
+import tensorflow.keras.layers
 
 
 # Prevents circular imports.
@@ -59,127 +46,127 @@ def get_current_layers():
     """
     Returns a list of currently available layers in Keras.
     """
-    class_set = set([(getattr(keras.layers, name), name)
-                     for name in dir(keras.layers)
-                     if (inspect.isclass(getattr(keras.layers, name)) and
-                         issubclass(getattr(keras.layers, name),
-                                    keras.engine.topology.Layer))])
+    class_set = set([(getattr(tensorflow.keras.layers, name), name)
+                     for name in dir(tensorflow.keras.layers)
+                     if (inspect.isclass(getattr(tensorflow.keras.layers, name)) and
+                         issubclass(getattr(tensorflow.keras.layers, name),
+                                    tensorflow.keras.layers.Layer))])
     return [x[1] for x in sorted((str(x[0]), x[1]) for x in class_set)]
 
 
 def get_known_layers():
     """
-    Returns a list of keras layer we are aware of.
+    Returns a list of tensorflow.keras layer we are aware of.
     """
 
     # Inside function to not break import if Keras changes.
     KNOWN_LAYERS = (
-        keras.engine.topology.InputLayer,
-        keras.layers.advanced_activations.ELU,
-        keras.layers.advanced_activations.LeakyReLU,
-        keras.layers.advanced_activations.PReLU,
-        keras.layers.advanced_activations.Softmax,
-        keras.layers.advanced_activations.ThresholdedReLU,
-        keras.layers.convolutional.Conv1D,
-        keras.layers.convolutional.Conv2D,
-        keras.layers.convolutional.Conv2DTranspose,
-        keras.layers.convolutional.Conv3D,
-        keras.layers.convolutional.Conv3DTranspose,
-        keras.layers.convolutional.Cropping1D,
-        keras.layers.convolutional.Cropping2D,
-        keras.layers.convolutional.Cropping3D,
-        keras.layers.convolutional.SeparableConv1D,
-        keras.layers.convolutional.SeparableConv2D,
-        keras.layers.convolutional.UpSampling1D,
-        keras.layers.convolutional.UpSampling2D,
-        keras.layers.convolutional.UpSampling3D,
-        keras.layers.convolutional.ZeroPadding1D,
-        keras.layers.convolutional.ZeroPadding2D,
-        keras.layers.convolutional.ZeroPadding3D,
-        keras.layers.convolutional_recurrent.ConvLSTM2D,
-        keras.layers.convolutional_recurrent.ConvRecurrent2D,
-        keras.layers.core.Activation,
-        keras.layers.core.ActivityRegularization,
-        keras.layers.core.Dense,
-        keras.layers.core.Dropout,
-        keras.layers.core.Flatten,
-        keras.layers.core.Lambda,
-        keras.layers.core.Masking,
-        keras.layers.core.Permute,
-        keras.layers.core.RepeatVector,
-        keras.layers.core.Reshape,
-        keras.layers.core.SpatialDropout1D,
-        keras.layers.core.SpatialDropout2D,
-        keras.layers.core.SpatialDropout3D,
-        keras.layers.cudnn_recurrent.CuDNNGRU,
-        keras.layers.cudnn_recurrent.CuDNNLSTM,
-        keras.layers.embeddings.Embedding,
-        keras.layers.local.LocallyConnected1D,
-        keras.layers.local.LocallyConnected2D,
-        keras.layers.Add,
-        keras.layers.Average,
-        keras.layers.Concatenate,
-        keras.layers.Dot,
-        keras.layers.Maximum,
-        keras.layers.Minimum,
-        keras.layers.Multiply,
-        keras.layers.Subtract,
-        keras.layers.noise.AlphaDropout,
-        keras.layers.noise.GaussianDropout,
-        keras.layers.noise.GaussianNoise,
-        keras.layers.normalization.BatchNormalization,
-        keras.layers.pooling.AveragePooling1D,
-        keras.layers.pooling.AveragePooling2D,
-        keras.layers.pooling.AveragePooling3D,
-        keras.layers.pooling.GlobalAveragePooling1D,
-        keras.layers.pooling.GlobalAveragePooling2D,
-        keras.layers.pooling.GlobalAveragePooling3D,
-        keras.layers.pooling.GlobalMaxPooling1D,
-        keras.layers.pooling.GlobalMaxPooling2D,
-        keras.layers.pooling.GlobalMaxPooling3D,
-        keras.layers.pooling.MaxPooling1D,
-        keras.layers.pooling.MaxPooling2D,
-        keras.layers.pooling.MaxPooling3D,
-        keras.layers.recurrent.GRU,
-        keras.layers.recurrent.GRUCell,
-        keras.layers.recurrent.LSTM,
-        keras.layers.recurrent.LSTMCell,
-        keras.layers.recurrent.RNN,
-        keras.layers.recurrent.SimpleRNN,
-        keras.layers.recurrent.SimpleRNNCell,
-        keras.layers.recurrent.StackedRNNCells,
-        keras.layers.wrappers.Bidirectional,
-        keras.layers.wrappers.TimeDistributed,
-        keras.layers.wrappers.Wrapper,
-        keras.legacy.layers.Highway,
-        keras.legacy.layers.MaxoutDense,
-        keras.legacy.layers.Merge,
-        keras.legacy.layers.Recurrent,
+        tensorflow.keras.layers.InputLayer,
+        tensorflow.keras.layers.ELU,
+        tensorflow.keras.layers.LeakyReLU,
+        tensorflow.keras.layers.PReLU,
+        tensorflow.keras.layers.Softmax,
+        tensorflow.keras.layers.ThresholdedReLU,
+        tensorflow.keras.layers.Conv1D,
+        tensorflow.keras.layers.Conv2D,
+        tensorflow.keras.layers.Conv2DTranspose,
+        tensorflow.keras.layers.Conv3D,
+        tensorflow.keras.layers.Conv3DTranspose,
+        tensorflow.keras.layers.Cropping1D,
+        tensorflow.keras.layers.Cropping2D,
+        tensorflow.keras.layers.Cropping3D,
+        tensorflow.keras.layers.SeparableConv1D,
+        tensorflow.keras.layers.SeparableConv2D,
+        tensorflow.keras.layers.UpSampling1D,
+        tensorflow.keras.layers.UpSampling2D,
+        tensorflow.keras.layers.UpSampling3D,
+        tensorflow.keras.layers.ZeroPadding1D,
+        tensorflow.keras.layers.ZeroPadding2D,
+        tensorflow.keras.layers.ZeroPadding3D,
+        tensorflow.keras.layers.ConvLSTM2D,
+        tensorflow.keras.layers.ConvRecurrent2D,
+        tensorflow.keras.layers.Activation,
+        tensorflow.keras.layers.ActivityRegularization,
+        tensorflow.keras.layers.Dense,
+        tensorflow.keras.layers.Dropout,
+        tensorflow.keras.layers.Flatten,
+        tensorflow.keras.layers.Lambda,
+        tensorflow.keras.layers.Masking,
+        tensorflow.keras.layers.Permute,
+        tensorflow.keras.layers.RepeatVector,
+        tensorflow.keras.layers.Reshape,
+        tensorflow.keras.layers.SpatialDropout1D,
+        tensorflow.keras.layers.SpatialDropout2D,
+        tensorflow.keras.layers.SpatialDropout3D,
+        tensorflow.keras.layers.CuDNNGRU,
+        tensorflow.keras.layers.CuDNNLSTM,
+        tensorflow.keras.layers.Embedding,
+        tensorflow.keras.layers.LocallyConnected1D,
+        tensorflow.keras.layers.LocallyConnected2D,
+        tensorflow.keras.layers.Add,
+        tensorflow.keras.layers.Average,
+        tensorflow.keras.layers.Concatenate,
+        tensorflow.keras.layers.Dot,
+        tensorflow.keras.layers.Maximum,
+        tensorflow.keras.layers.Minimum,
+        tensorflow.keras.layers.Multiply,
+        tensorflow.keras.layers.Subtract,
+        tensorflow.keras.layers.AlphaDropout,
+        tensorflow.keras.layers.GaussianDropout,
+        tensorflow.keras.layers.GaussianNoise,
+        tensorflow.keras.layers.BatchNormalization,
+        tensorflow.keras.layers.AveragePooling1D,
+        tensorflow.keras.layers.AveragePooling2D,
+        tensorflow.keras.layers.AveragePooling3D,
+        tensorflow.keras.layers.GlobalAveragePooling1D,
+        tensorflow.keras.layers.GlobalAveragePooling2D,
+        tensorflow.keras.layers.GlobalAveragePooling3D,
+        tensorflow.keras.layers.GlobalMaxPooling1D,
+        tensorflow.keras.layers.GlobalMaxPooling2D,
+        tensorflow.keras.layers.GlobalMaxPooling3D,
+        tensorflow.keras.layers.MaxPooling1D,
+        tensorflow.keras.layers.MaxPooling2D,
+        tensorflow.keras.layers.MaxPooling3D,
+        tensorflow.keras.layers.GRU,
+        tensorflow.keras.layers.GRUCell,
+        tensorflow.keras.layers.LSTM,
+        tensorflow.keras.layers.LSTMCell,
+        tensorflow.keras.layers.RNN,
+        tensorflow.keras.layers.SimpleRNN,
+        tensorflow.keras.layers.SimpleRNNCell,
+        tensorflow.keras.layers.StackedRNNCells,
+        tensorflow.keras.layers.Bidirectional,
+        tensorflow.keras.layers.TimeDistributed,
+        tensorflow.keras.layers.Wrapper,
+        tensorflow.keras.layers.Highway,
+        tensorflow.keras.layers.MaxoutDense,
+        tensorflow.keras.layers.Merge,
+        tensorflow.keras.layers.Recurrent,
     )
     return KNOWN_LAYERS
 
 
 def get_activation_search_safe_layers():
     """
-    Returns a list of keras layer that we can walk along
+    Returns a list of tensorflow.keras layer that we can walk along
     in an activation search.
     """
 
     # Inside function to not break import if Keras changes.
     ACTIVATION_SEARCH_SAFE_LAYERS = (
-        keras.layers.advanced_activations.ELU,
-        keras.layers.advanced_activations.LeakyReLU,
-        keras.layers.advanced_activations.PReLU,
-        keras.layers.advanced_activations.Softmax,
-        keras.layers.advanced_activations.ThresholdedReLU,
-        keras.layers.core.Activation,
-        keras.layers.core.ActivityRegularization,
-        keras.layers.core.Dropout,
-        keras.layers.core.Flatten,
-        keras.layers.core.Reshape,
-        keras.layers.Add,
-        keras.layers.noise.GaussianNoise,
-        keras.layers.normalization.BatchNormalization,
+        tensorflow.keras.layers.ELU,
+        tensorflow.keras.layers.LeakyReLU,
+        tensorflow.keras.layers.PReLU,
+        tensorflow.keras.layers.Softmax,
+        tensorflow.keras.layers.ThresholdedReLU,
+        tensorflow.keras.layers.Activation,
+        tensorflow.keras.layers.ActivityRegularization,
+        tensorflow.keras.layers.Dropout,
+        tensorflow.keras.layers.Flatten,
+        tensorflow.keras.layers.Reshape,
+        tensorflow.keras.layers.Add,
+        tensorflow.keras.layers.GaussianNoise,
+        tensorflow.keras.layers.BatchNormalization,
     )
     return ACTIVATION_SEARCH_SAFE_LAYERS
 
@@ -199,21 +186,21 @@ def contains_activation(layer, activation=None):
     # rely on Keras convention.
     if hasattr(layer, "activation"):
         if activation is not None:
-            return layer.activation == keras.activations.get(activation)
+            return layer.activation == tensorflow.keras.activations.get(activation)
         else:
             return True
-    elif isinstance(layer, keras.layers.ReLU):
+    elif isinstance(layer, tensorflow.keras.layers.ReLU):
         if activation is not None:
-            return (keras.activations.get("relu") ==
-                    keras.activations.get(activation))
+            return (tensorflow.keras.activations.get("relu") ==
+                    tensorflow.keras.activations.get(activation))
         else:
             return True
     elif isinstance(layer, (
-            keras.layers.advanced_activations.ELU,
-            keras.layers.advanced_activations.LeakyReLU,
-            keras.layers.advanced_activations.PReLU,
-            keras.layers.advanced_activations.Softmax,
-            keras.layers.advanced_activations.ThresholdedReLU)):
+            tensorflow.keras.layers.ELU,
+            tensorflow.keras.layers.LeakyReLU,
+            tensorflow.keras.layers.PReLU,
+            tensorflow.keras.layers.Softmax,
+            tensorflow.keras.layers.ThresholdedReLU)):
         if activation is not None:
             raise Exception("Cannot detect activation type.")
         else:
@@ -260,105 +247,106 @@ def is_network(layer):
     """
     Is network in network?
     """
-    return isinstance(layer, keras.engine.topology.Network)
+    from tcn.tcn import ResidualBlock, TCN
+    return isinstance(layer, ResidualBlock) or isinstance(layer, TCN)
 
 
 def is_conv_layer(layer, *args, **kwargs):
     """Checks if layer is a convolutional layer."""
     CONV_LAYERS = (
-        keras.layers.convolutional.Conv1D,
-        keras.layers.convolutional.Conv2D,
-        keras.layers.convolutional.Conv2DTranspose,
-        keras.layers.convolutional.Conv3D,
-        keras.layers.convolutional.Conv3DTranspose,
-        keras.layers.convolutional.SeparableConv1D,
-        keras.layers.convolutional.SeparableConv2D,
-        keras.layers.convolutional.DepthwiseConv2D
+        tensorflow.keras.layers.Conv1D,
+        tensorflow.keras.layers.Conv2D,
+        tensorflow.keras.layers.Conv2DTranspose,
+        tensorflow.keras.layers.Conv3D,
+        tensorflow.keras.layers.Conv3DTranspose,
+        tensorflow.keras.layers.SeparableConv1D,
+        tensorflow.keras.layers.SeparableConv2D,
+        tensorflow.keras.layers.DepthwiseConv2D
     )
     return isinstance(layer, CONV_LAYERS)
 
 
 def is_batch_normalization_layer(layer, *args, **kwargs):
     """Checks if layer is a batchnorm layer."""
-    return isinstance(layer, keras.layers.normalization.BatchNormalization)
+    return isinstance(layer, tensorflow.keras.layers.BatchNormalization)
 
 
 def is_add_layer(layer, *args, **kwargs):
     """Checks if layer is an addition-merge layer."""
-    return isinstance(layer, keras.layers.Add)
+    return isinstance(layer, tensorflow.keras.layers.Add)
 
 
 def is_dense_layer(layer, *args, **kwargs):
     """Checks if layer is a dense layer."""
-    return isinstance(layer, keras.layers.core.Dense)
+    return isinstance(layer, tensorflow.keras.layers.Dense)
 
 
 def is_convnet_layer(layer):
     """Checks if layer is from a convolutional network."""
     # Inside function to not break import if Keras changes.
     CONVNET_LAYERS = (
-        keras.engine.topology.InputLayer,
-        keras.layers.advanced_activations.ELU,
-        keras.layers.advanced_activations.LeakyReLU,
-        keras.layers.advanced_activations.PReLU,
-        keras.layers.advanced_activations.Softmax,
-        keras.layers.advanced_activations.ThresholdedReLU,
-        keras.layers.convolutional.Conv1D,
-        keras.layers.convolutional.Conv2D,
-        keras.layers.convolutional.Conv2DTranspose,
-        keras.layers.convolutional.Conv3D,
-        keras.layers.convolutional.Conv3DTranspose,
-        keras.layers.convolutional.Cropping1D,
-        keras.layers.convolutional.Cropping2D,
-        keras.layers.convolutional.Cropping3D,
-        keras.layers.convolutional.SeparableConv1D,
-        keras.layers.convolutional.SeparableConv2D,
-        keras.layers.convolutional.UpSampling1D,
-        keras.layers.convolutional.UpSampling2D,
-        keras.layers.convolutional.UpSampling3D,
-        keras.layers.convolutional.ZeroPadding1D,
-        keras.layers.convolutional.ZeroPadding2D,
-        keras.layers.convolutional.ZeroPadding3D,
-        keras.layers.core.Activation,
-        keras.layers.core.ActivityRegularization,
-        keras.layers.core.Dense,
-        keras.layers.core.Dropout,
-        keras.layers.core.Flatten,
-        keras.layers.core.Lambda,
-        keras.layers.core.Masking,
-        keras.layers.core.Permute,
-        keras.layers.core.RepeatVector,
-        keras.layers.core.Reshape,
-        keras.layers.core.SpatialDropout1D,
-        keras.layers.core.SpatialDropout2D,
-        keras.layers.core.SpatialDropout3D,
-        keras.layers.embeddings.Embedding,
-        keras.layers.local.LocallyConnected1D,
-        keras.layers.local.LocallyConnected2D,
-        keras.layers.Add,
-        keras.layers.Average,
-        keras.layers.Concatenate,
-        keras.layers.Dot,
-        keras.layers.Maximum,
-        keras.layers.Minimum,
-        keras.layers.Multiply,
-        keras.layers.Subtract,
-        keras.layers.noise.AlphaDropout,
-        keras.layers.noise.GaussianDropout,
-        keras.layers.noise.GaussianNoise,
-        keras.layers.normalization.BatchNormalization,
-        keras.layers.pooling.AveragePooling1D,
-        keras.layers.pooling.AveragePooling2D,
-        keras.layers.pooling.AveragePooling3D,
-        keras.layers.pooling.GlobalAveragePooling1D,
-        keras.layers.pooling.GlobalAveragePooling2D,
-        keras.layers.pooling.GlobalAveragePooling3D,
-        keras.layers.pooling.GlobalMaxPooling1D,
-        keras.layers.pooling.GlobalMaxPooling2D,
-        keras.layers.pooling.GlobalMaxPooling3D,
-        keras.layers.pooling.MaxPooling1D,
-        keras.layers.pooling.MaxPooling2D,
-        keras.layers.pooling.MaxPooling3D,
+        tensorflow.keras.layers.InputLayer,
+        tensorflow.keras.layers.ELU,
+        tensorflow.keras.layers.LeakyReLU,
+        tensorflow.keras.layers.PReLU,
+        tensorflow.keras.layers.Softmax,
+        tensorflow.keras.layers.ThresholdedReLU,
+        tensorflow.keras.layers.Conv1D,
+        tensorflow.keras.layers.Conv2D,
+        tensorflow.keras.layers.Conv2DTranspose,
+        tensorflow.keras.layers.Conv3D,
+        tensorflow.keras.layers.Conv3DTranspose,
+        tensorflow.keras.layers.Cropping1D,
+        tensorflow.keras.layers.Cropping2D,
+        tensorflow.keras.layers.Cropping3D,
+        tensorflow.keras.layers.SeparableConv1D,
+        tensorflow.keras.layers.SeparableConv2D,
+        tensorflow.keras.layers.UpSampling1D,
+        tensorflow.keras.layers.UpSampling2D,
+        tensorflow.keras.layers.UpSampling3D,
+        tensorflow.keras.layers.ZeroPadding1D,
+        tensorflow.keras.layers.ZeroPadding2D,
+        tensorflow.keras.layers.ZeroPadding3D,
+        tensorflow.keras.layers.Activation,
+        tensorflow.keras.layers.ActivityRegularization,
+        tensorflow.keras.layers.Dense,
+        tensorflow.keras.layers.Dropout,
+        tensorflow.keras.layers.Flatten,
+        tensorflow.keras.layers.Lambda,
+        tensorflow.keras.layers.Masking,
+        tensorflow.keras.layers.Permute,
+        tensorflow.keras.layers.RepeatVector,
+        tensorflow.keras.layers.Reshape,
+        tensorflow.keras.layers.SpatialDropout1D,
+        tensorflow.keras.layers.SpatialDropout2D,
+        tensorflow.keras.layers.SpatialDropout3D,
+        tensorflow.keras.layers.Embedding,
+        tensorflow.keras.layers.LocallyConnected1D,
+        tensorflow.keras.layers.LocallyConnected2D,
+        tensorflow.keras.layers.Add,
+        tensorflow.keras.layers.Average,
+        tensorflow.keras.layers.Concatenate,
+        tensorflow.keras.layers.Dot,
+        tensorflow.keras.layers.Maximum,
+        tensorflow.keras.layers.Minimum,
+        tensorflow.keras.layers.Multiply,
+        tensorflow.keras.layers.Subtract,
+        tensorflow.keras.layers.AlphaDropout,
+        tensorflow.keras.layers.GaussianDropout,
+        tensorflow.keras.layers.GaussianNoise,
+        tensorflow.keras.layers.BatchNormalization,
+        tensorflow.keras.layers.AveragePooling1D,
+        tensorflow.keras.layers.AveragePooling2D,
+        tensorflow.keras.layers.AveragePooling3D,
+        tensorflow.keras.layers.GlobalAveragePooling1D,
+        tensorflow.keras.layers.GlobalAveragePooling2D,
+        tensorflow.keras.layers.GlobalAveragePooling3D,
+        tensorflow.keras.layers.GlobalMaxPooling1D,
+        tensorflow.keras.layers.GlobalMaxPooling2D,
+        tensorflow.keras.layers.GlobalMaxPooling3D,
+        tensorflow.keras.layers.MaxPooling1D,
+        tensorflow.keras.layers.MaxPooling2D,
+        tensorflow.keras.layers.MaxPooling3D,
     )
     return isinstance(layer, CONVNET_LAYERS)
 
@@ -371,12 +359,12 @@ def is_relu_convnet_layer(layer):
 def is_average_pooling(layer):
     """Checks if layer is an average-pooling layer."""
     AVERAGEPOOLING_LAYERS = (
-        keras.layers.pooling.AveragePooling1D,
-        keras.layers.pooling.AveragePooling2D,
-        keras.layers.pooling.AveragePooling3D,
-        keras.layers.pooling.GlobalAveragePooling1D,
-        keras.layers.pooling.GlobalAveragePooling2D,
-        keras.layers.pooling.GlobalAveragePooling3D,
+        tensorflow.keras.layers.AveragePooling1D,
+        tensorflow.keras.layers.AveragePooling2D,
+        tensorflow.keras.layers.AveragePooling3D,
+        tensorflow.keras.layers.GlobalAveragePooling1D,
+        tensorflow.keras.layers.GlobalAveragePooling2D,
+        tensorflow.keras.layers.GlobalAveragePooling3D,
     )
     return isinstance(layer, AVERAGEPOOLING_LAYERS)
 
@@ -384,12 +372,12 @@ def is_average_pooling(layer):
 def is_max_pooling(layer):
     """Checks if layer is a max-pooling layer."""
     MAXPOOLING_LAYERS = (
-        keras.layers.pooling.MaxPooling1D,
-        keras.layers.pooling.MaxPooling2D,
-        keras.layers.pooling.MaxPooling3D,
-        keras.layers.pooling.GlobalMaxPooling1D,
-        keras.layers.pooling.GlobalMaxPooling2D,
-        keras.layers.pooling.GlobalMaxPooling3D,
+        tensorflow.keras.layers.MaxPooling1D,
+        tensorflow.keras.layers.MaxPooling2D,
+        tensorflow.keras.layers.MaxPooling3D,
+        tensorflow.keras.layers.GlobalMaxPooling1D,
+        tensorflow.keras.layers.GlobalMaxPooling2D,
+        tensorflow.keras.layers.GlobalMaxPooling3D,
     )
     return isinstance(layer, MAXPOOLING_LAYERS)
 
@@ -407,9 +395,9 @@ def is_input_layer(layer, ignore_reshape_layers=True):
     # the data content.
     # todo: update this list!
     IGNORED_LAYERS = (
-        keras.layers.Flatten,
-        keras.layers.Permute,
-        keras.layers.Reshape,
+        tensorflow.keras.layers.Flatten,
+        tensorflow.keras.layers.Permute,
+        tensorflow.keras.layers.Reshape,
     )
     while any([isinstance(x, IGNORED_LAYERS) for x in layer_inputs]):
         tmp = set()
@@ -421,7 +409,7 @@ def is_input_layer(layer, ignore_reshape_layers=True):
                 tmp.add(l)
         layer_inputs = tmp
 
-    if all([isinstance(x, keras.layers.InputLayer)
+    if all([isinstance(x, tensorflow.keras.layers.InputLayer)
             for x in layer_inputs]):
         return True
     else:

--- a/innvestigate/utils/keras/graph.py
+++ b/innvestigate/utils/keras/graph.py
@@ -573,8 +573,6 @@ def trace_model_execution(model, reapply_on_copied_layers=False):
 
         executed_nodes = reversed(reverse_executed_nodes)
 
-    # TODO: tutaj jescze wszystko jest
-    # import ipdb; ipdb.set_trace()
     executed_nodes = _get_executed_nodes(executed_nodes, outputs)
 
     return layers, executed_nodes, outputs

--- a/innvestigate/utils/tests/dryrun.py
+++ b/innvestigate/utils/tests/dryrun.py
@@ -9,8 +9,8 @@ import six
 ###############################################################################
 
 
-import keras.backend as K
-import keras.models
+import tensorflow.keras.backend as K
+import tensorflow.keras.models
 import numpy as np
 import unittest
 
@@ -101,7 +101,7 @@ class AnalyzerTestCase(BaseLayerTestCase):
 
     def _apply_test(self, network):
         # Create model.
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
         model.set_weights(_set_zero_weights_to_random(model.get_weights()))
         # Get analyzer.
@@ -146,7 +146,7 @@ class AnalyzerTrainTestCase(BaseLayerTestCase):
 
     def _apply_test(self, network):
         # Create model.
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
         model.set_weights(_set_zero_weights_to_random(model.get_weights()))
         # Get analyzer.
@@ -203,7 +203,7 @@ class EqualAnalyzerTestCase(BaseLayerTestCase):
 
     def _apply_test(self, network):
         # Create model.
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
         model.set_weights(_set_zero_weights_to_random(model.get_weights()))
         # Get analyzer.
@@ -267,7 +267,7 @@ class SerializeAnalyzerTestCase(BaseLayerTestCase):
 
     def _apply_test(self, network):
         # Create model.
-        model = keras.models.Model(inputs=network["in"],
+        model = tensorflow.keras.models.Model(inputs=network["in"],
                                    outputs=network["out"])
         model.set_weights(_set_zero_weights_to_random(model.get_weights()))
         # Get analyzer.
@@ -318,7 +318,7 @@ class PatternComputerTestCase(BaseLayerTestCase):
 
     def _apply_test(self, network):
         # Create model.
-        model = keras.models.Model(inputs=network["in"], outputs=network["out"])
+        model = tensorflow.keras.models.Model(inputs=network["in"], outputs=network["out"])
         model.set_weights(_set_zero_weights_to_random(model.get_weights()))
         # Get computer.
         computer = self._method(model)

--- a/innvestigate/utils/tests/layer.py
+++ b/innvestigate/utils/tests/layer.py
@@ -9,8 +9,8 @@ from builtins import range
 ###############################################################################
 
 
-import keras.models
-import keras.engine.topology
+import tensorflow.keras.models
+import tensorflow.keras.engine.topology
 
 
 from ... import utils as iutils
@@ -36,19 +36,19 @@ class TestAnalysisHelper(object):
           In this case a sequntial model will be build. The first layer
           must have set input_shape or batch_input_shape.
           Alternatively a tuple with input and output tensors, in which
-          case the keras modle api will be used.
+          case the tensorflow.keras modle api will be used.
         :param analyzer: Either an analyzer class or a function
-          that takes a keras model and returns an analyzer.
+          that takes a tensorflow.keras model and returns an analyzer.
         :param weights: After creating the model set the given weights.
         """
 
-        if isinstance(model, keras.engine.topology.Layer):
+        if isinstance(model, tensorflow.keras.engine.topology.Layer):
             model = [model]
 
         if isinstance(model, list):
-            self._model = keras.models.Sequential(model)
+            self._model = tensorflow.keras.models.Sequential(model)
         else:
-            self._model = keras.models.Model(*model)
+            self._model = tensorflow.keras.models.Model(*model)
 
         self._input_shapes = iutils.to_list(self._model.input_shape)
 

--- a/innvestigate/utils/tests/networks/__init__.py
+++ b/innvestigate/utils/tests/networks/__init__.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 import fnmatch
 
 from . import trivia

--- a/innvestigate/utils/tests/networks/base.py
+++ b/innvestigate/utils/tests/networks/base.py
@@ -8,7 +8,7 @@ from builtins import range
 ###############################################################################
 ###############################################################################
 
-import keras.layers
+import tensorflow.keras.layers
 
 
 __all__ = [
@@ -32,15 +32,15 @@ __all__ = [
 # TODO: more consistent nameing
 
 def input_layer(shape, *args, **kwargs):
-    return keras.layers.Input(shape=shape[1:], *args, **kwargs)
+    return tensorflow.keras.layers.Input(shape=shape[1:], *args, **kwargs)
 
 
 def dense_layer(layer_in, *args, **kwargs):
-    return keras.layers.Dense(*args, **kwargs)(layer_in)
+    return tensorflow.keras.layers.Dense(*args, **kwargs)(layer_in)
 
 
 def conv_layer(layer_in, *args, **kwargs):
-    return keras.layers.Conv2D(*args, **kwargs)(layer_in)
+    return tensorflow.keras.layers.Conv2D(*args, **kwargs)(layer_in)
 
 
 def conv_pool(layer_in, n_conv, prefix, n_filter, **kwargs):
@@ -55,7 +55,7 @@ def conv_pool(layer_in, n_conv, prefix, n_filter, **kwargs):
         current_layer = conv
         ret[conv_prefix % i] = conv
 
-        ret["%s_pool" % prefix] = keras.layers.MaxPooling2D(
+        ret["%s_pool" % prefix] = tensorflow.keras.layers.MaxPooling2D(
             pool_size=(2, 2),
             strides=(2, 2),
         )(current_layer)
@@ -63,11 +63,11 @@ def conv_pool(layer_in, n_conv, prefix, n_filter, **kwargs):
 
 
 def dropout_layer(layer_in, *args, **kwargs):
-    return keras.layers.Dropout(*args, **kwargs)(layer_in)
+    return tensorflow.keras.layers.Dropout(*args, **kwargs)(layer_in)
 
 
 def softmax(layer_in):
-    return keras.layers.Activation("softmax")(layer_in)
+    return tensorflow.keras.layers.Activation("softmax")(layer_in)
 
 
 ###############################################################################
@@ -81,7 +81,7 @@ def log_reg(input_shape, output_n, activation=None):
 
     net = {}
     net["in"] = input_layer(shape=input_shape)
-    net["in_flat"] = keras.layers.Flatten()(net["in"])
+    net["in_flat"] = tensorflow.keras.layers.Flatten()(net["in"])
     net["out"] = dense_layer(net["in_flat"], units=output_n,
                              kernel_initializer="glorot_uniform")
     net["sm_out"] = softmax(net["out"])
@@ -106,7 +106,7 @@ def mlp_2dense(input_shape, output_n, activation=None,
 
     net = {}
     net["in"] = input_layer(shape=input_shape)
-    net["in_flat"] = keras.layers.Flatten()(net["in"])
+    net["in_flat"] = tensorflow.keras.layers.Flatten()(net["in"])
     net["dense_1"] = dense_layer(net["in_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")
@@ -130,7 +130,7 @@ def mlp_3dense(input_shape, output_n, activation=None,
 
     net = {}
     net["in"] = input_layer(shape=input_shape)
-    net["in_flat"] = keras.layers.Flatten()(net["in"])
+    net["in_flat"] = tensorflow.keras.layers.Flatten()(net["in"])
     net["dense_1"] = dense_layer(net["in_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")
@@ -165,7 +165,7 @@ def cnn_1convb_2dense(input_shape, output_n, activation=None,
     net["in"] = input_layer(shape=input_shape)
     net.update(conv_pool(net["in"], 2, "conv_1", 128,
                          activation=activation))
-    net["conv_flat"] = keras.layers.Flatten()(net["conv_1_pool"])
+    net["conv_flat"] = tensorflow.keras.layers.Flatten()(net["conv_1_pool"])
     net["dense_1"] = dense_layer(net["conv_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")
@@ -193,7 +193,7 @@ def cnn_2convb_2dense(input_shape, output_n, activation=None,
                          activation=activation))
     net.update(conv_pool(net["conv_1_pool"], 2, "conv_2", 128,
                          activation=activation))
-    net["conv_flat"] = keras.layers.Flatten()(net["conv_2_pool"])
+    net["conv_flat"] = tensorflow.keras.layers.Flatten()(net["conv_2_pool"])
     net["dense_1"] = dense_layer(net["conv_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")
@@ -221,7 +221,7 @@ def cnn_2convb_3dense(input_shape, output_n, activation=None,
                          activation=activation))
     net.update(conv_pool(net["conv_1_pool"], 2, "conv_2", 128,
                          activation=activation))
-    net["conv_flat"] = keras.layers.Flatten()(net["conv_2_pool"])
+    net["conv_flat"] = tensorflow.keras.layers.Flatten()(net["conv_2_pool"])
     net["dense_1"] = dense_layer(net["conv_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")
@@ -255,7 +255,7 @@ def cnn_3convb_3dense(input_shape, output_n, activation=None,
                          activation=activation))
     net.update(conv_pool(net["conv_2_pool"], 2, "conv_3", 128,
                          activation=activation))
-    net["conv_flat"] = keras.layers.Flatten()(net["conv_3_pool"])
+    net["conv_flat"] = tensorflow.keras.layers.Flatten()(net["conv_3_pool"])
     net["dense_1"] = dense_layer(net["conv_flat"], units=dense_units,
                                  activation=activation,
                                  kernel_initializer="glorot_uniform")

--- a/innvestigate/utils/tests/networks/cifar10.py
+++ b/innvestigate/utils/tests/networks/cifar10.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 
 from . import base
 

--- a/innvestigate/utils/tests/networks/imagenet.py
+++ b/innvestigate/utils/tests/networks/imagenet.py
@@ -8,8 +8,8 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.backend as K
-import keras.layers
+import tensorflow.keras.backend as K
+import tensorflow.keras.layers
 import numpy as np
 import warnings
 
@@ -89,7 +89,7 @@ def vgg16_custom(activation=None):
         activation=activation,
     ))
 
-    net["conv_flat"] = keras.layers.Flatten()(net["conv_5_pool"])
+    net["conv_flat"] = tensorflow.keras.layers.Flatten()(net["conv_5_pool"])
     net["dense_1"] = base.dense_layer(net["conv_flat"], units=4096,
                                       activation=activation,
                                       kernel_initializer="glorot_uniform")

--- a/innvestigate/utils/tests/networks/mnist.py
+++ b/innvestigate/utils/tests/networks/mnist.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.backend as K
+import tensorflow.keras.backend as K
 
 from . import base
 

--- a/innvestigate/utils/tests/networks/trivia.py
+++ b/innvestigate/utils/tests/networks/trivia.py
@@ -8,7 +8,7 @@ from __future__ import\
 ###############################################################################
 
 
-import keras.layers
+import tensorflow.keras.layers
 
 from . import base
 
@@ -50,10 +50,10 @@ def skip_connection():
 
     net = {}
     net["in"] = base.input_layer(shape=input_shape)
-    dense = keras.layers.Dense(units=output_n,
+    dense = tensorflow.keras.layers.Dense(units=output_n,
                                activation="linear",
                                use_bias=False)
-    net["out"] = keras.layers.Add()([net["in"], dense(net["in"])])
+    net["out"] = tensorflow.keras.layers.Add()([net["in"], dense(net["in"])])
 
     net.update({
         "input_shape": input_shape,


### PR DESCRIPTION
I was using the Innvestigate library to perform LRP analysis of my Temporal Convolutional Network that I use for predicting fundamental frequency of speech from thousands of linguistic features. The visualisations allow me to see the relevance of feature groups (like type of syllable accent and syllable position) for intonation contours. The algorithm in Innvestigate is great and quite speedy but I found it difficult to use directly with my Tensorflow 2.0 Keras Sequential network. The reason is mainly in the import statements that you use. This PR is a potential discussion starter as I think it would be much better not to import libraries as whole paths, i.e. instead of importing `tensorflow.keras.layers.convolutional.UpSampling1D` we should probably just import `UpSampling1D`. 
Also the eager execution setting in TF and the way I have implemented in my scripts do not allow some operations on tensors like list comprehensions etc. (AFAIK they are simply not yet implemented in the TF API).

If you think this is helpful at all please let me know and I will be happy to help tidy this up or we can discuss this further.

Anyways, thanks you for a great library!