### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+### Read the docs
+Before opening an issue, try to find a solution in the [iNNvestigate docs](https://innvestigate.readthedocs.io/en/latest/) and consider using the issue search function to look for similar issues. Thanks!
+___
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### Steps to reproduce the bug
+Ideally include a minimal code example in Python that reproduces the bug:
+
+```python
+"Replace me with your code!"
+```
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Platform information
+ - OS: [e.g. Ubuntu 20.04, Windows 10]
+ - Python version: [e.g. 3.7, 3.8, 3.9]
+ - iNNvestigate version: [e.g. 1.0.9]
+ - TensorFlow version: [e.g. 1.15]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[REQUEST]"
+labels: ''
+assignees: ''
+
+---
+
+### Look for similar feature requests
+Before opening an issue, try to find similar feature requests using the issue search function. Thanks!
+___
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is.
+
+### How would you improve iNNvestigate?
+A clear and concise description of what you want to happen.
+
+### Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
In case these templates aren't automatically recognised, they will have to be activated under `Settings>Features>Issues` as described [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates).

Feel free to modify the templates based on your experience. ;)