### PR TITLE
Fix `is_layer_at_idx` for LRP

### DIFF
--- a/src/innvestigate/analyzer/relevance_based/relevance_analyzer.py
+++ b/src/innvestigate/analyzer/relevance_based/relevance_analyzer.py
@@ -394,7 +394,9 @@ class LRP(ReverseAnalyzerBase):
         # apply rule to first self._until_layer_idx layers
         if self._until_layer_rule is not None and self._until_layer_idx is not None:
             for i in range(self._until_layer_idx + 1):
-                is_at_idx: LayerCheck = lambda layer: ichecks.is_layer_at_idx(layer, i)
+                is_at_idx: LayerCheck = lambda layer, i=i: ichecks.is_layer_at_idx(
+                    model, layer, i
+                )
                 rules.insert(0, (is_at_idx, self._until_layer_rule))
 
         # create a BoundedRule for input layer handling from given tuple

--- a/src/innvestigate/backend/checks.py
+++ b/src/innvestigate/backend/checks.py
@@ -7,7 +7,7 @@ import tensorflow.keras.layers as klayers
 from tensorflow import Module, keras
 
 import innvestigate.backend as ibackend
-from innvestigate.backend.types import Layer
+from innvestigate.backend.types import Layer, Model
 
 __all__ = [
     "get_activation_search_safe_layers",
@@ -325,8 +325,6 @@ def is_input_layer(layer: Layer, ignore_reshape_layers: bool = True) -> bool:
     return all(isinstance(x, klayers.InputLayer) for x in layer_inputs)
 
 
-def is_layer_at_idx(layer: Layer, index, ignore_reshape_layers=True) -> bool:
-    """Checks if layer is a layer at index index,
-    by repeatedly applying is_input_layer()."""
-    # TODO: implement layer index check
-    raise NotImplementedError("Layer index checking hasn't been implemented yet.")
+def is_layer_at_idx(model: Model, layer: Layer, index) -> bool:
+    """Checks if layer is a layer at specified index of model."""
+    return layer == model.layers(index)


### PR DESCRIPTION
Fixes the `is_layer_at_idx` function by binding the loop variable `i` to the lambda function and looping through the model's layers to find the corresponding index.

Closes #264 

### Example of fix

I have used a simple CNN network to test the implementation, see below the model summary.

![model_summary](https://user-images.githubusercontent.com/50332377/218184348-4278ec92-8416-46b7-9525-f294e1cbebce.png)

I used the following LRP settings.
```
analyzer = LRP(
    model,
    rule="Z",
    input_layer_rule="Flat",
    until_layer_idx=3,
    until_layer_rule="Epsilon",
)
```
For verification, I printed the rule object and the layer it will be applied to.

![layer+rule](https://user-images.githubusercontent.com/50332377/218185927-38f2f9eb-db40-4e12-b52f-e6e1327f1912.png)

As you can see all three rules are being applied.

### Discussion

The `until_layer_idx` argument will now count every layer in your model, also Input, Reshape, Pooling, etc.